### PR TITLE
Update branding URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Europa](https://cdn.rawgit.com/neocotic/europa-branding/master/assets/banner/europa/europa-banner-500x200.png)
+![Europa](https://raw.githubusercontent.com/neocotic/europa-branding/main/assets/banner/europa/europa-banner-500x200.png)
 
 [![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/neocotic/europa.svg?style=flat-square)](https://github.com/neocotic/europa/blob/main/LICENSE.md)

--- a/packages/europa-build/README.md
+++ b/packages/europa-build/README.md
@@ -1,4 +1,4 @@
-![Europa Build](https://cdn.rawgit.com/neocotic/europa-branding/master/assets/banner/europa-build/europa-build-banner-738x200.png)
+![Europa Build](https://raw.githubusercontent.com/neocotic/europa-branding/main/assets/banner/europa-build/europa-build-banner-738x200.png)
 
 [Europa Build](https://github.com/neocotic/europa/tree/main/packages/europa-build) is a tool for generating and
 maintaining [Europa](https://github.com/neocotic/europa) plugin and preset packages.

--- a/packages/europa-core/README.md
+++ b/packages/europa-core/README.md
@@ -1,4 +1,4 @@
-![Europa Core](https://cdn.rawgit.com/neocotic/europa-branding/master/assets/banner/europa-core/europa-core-banner-742x200.png)
+![Europa Core](https://raw.githubusercontent.com/neocotic/europa-branding/main/assets/banner/europa-core/europa-core-banner-742x200.png)
 
 [Europa Core](https://github.com/neocotic/europa/tree/main/packages/europa-core) is the core engine for
 [Europa](https://github.com/neocotic/europa)'s HTML to Markdown conversion.

--- a/packages/europa-plugin-image/README.md
+++ b/packages/europa-plugin-image/README.md
@@ -47,8 +47,8 @@ The following HTML tags are converted by this plugin:
 HTML:
 
 ``` html
-<img src="https://cdn.rawgit.com/neocotic/europa-branding/master/assets/banner/europa/europa-banner-250x100.png">
-<img src="https://cdn.rawgit.com/neocotic/europa-branding/master/assets/banner/node-europa/node-europa-banner-377x100.png" alt="Europa Node">
+<img src="https://raw.githubusercontent.com/neocotic/europa-branding/main/assets/banner/europa/europa-banner-250x100.png">
+<img src="https://raw.githubusercontent.com/neocotic/europa-branding/main/assets/banner/node-europa/node-europa-banner-377x100.png" alt="Europa Node">
 ```
 
 Markdown:
@@ -57,8 +57,8 @@ Markdown:
 ![][image0]
 ![Europa Node][image1]
 
-[image0]: https://cdn.rawgit.com/neocotic/europa-branding/master/assets/banner/europa/europa-banner-250x100.png
-[image1]: https://cdn.rawgit.com/neocotic/europa-branding/master/assets/banner/node-europa/node-europa-banner-377x100.png
+[image0]: https://raw.githubusercontent.com/neocotic/europa-branding/main/assets/banner/europa/europa-banner-250x100.png
+[image1]: https://raw.githubusercontent.com/neocotic/europa-branding/main/assets/banner/node-europa/node-europa-banner-377x100.png
 ```
 
 ### Absolute Option Enabled
@@ -74,8 +74,8 @@ const europa = new Europa({ absolute: true });
 HTML:
 
 ``` html
-<img src="//cdn.rawgit.com/neocotic/europa-branding/master/assets/banner/europa/europa-banner-250x100.png">
-<img src="//cdn.rawgit.com/neocotic/europa-branding/master/assets/banner/node-europa/node-europa-banner-377x100.png" alt="Europa Node">
+<img src="//raw.githubusercontent.com/neocotic/europa-branding/main/assets/banner/europa/europa-banner-250x100.png">
+<img src="//raw.githubusercontent.com/neocotic/europa-branding/main/assets/banner/node-europa/node-europa-banner-377x100.png" alt="Europa Node">
 ```
 
 Markdown:
@@ -84,8 +84,8 @@ Markdown:
 ![][image0]
 ![Europa Node][image1]
 
-[image0]: https://cdn.rawgit.com/neocotic/europa-branding/master/assets/banner/europa/europa-banner-250x100.png
-[image1]: https://cdn.rawgit.com/neocotic/europa-branding/master/assets/banner/node-europa/node-europa-banner-377x100.png
+[image0]: https://raw.githubusercontent.com/neocotic/europa-branding/main/assets/banner/europa/europa-banner-250x100.png
+[image1]: https://raw.githubusercontent.com/neocotic/europa-branding/main/assets/banner/node-europa/node-europa-banner-377x100.png
 ```
 
 ### Inline Option Enabled
@@ -99,15 +99,15 @@ const europa = new Europa({ inline: true });
 HTML:
 
 ``` html
-<img src="https://cdn.rawgit.com/neocotic/europa-branding/master/assets/banner/europa/europa-banner-250x100.png">
-<img src="https://cdn.rawgit.com/neocotic/europa-branding/master/assets/banner/node-europa/node-europa-banner-377x100.png" alt="Europa Node">
+<img src="https://raw.githubusercontent.com/neocotic/europa-branding/main/assets/banner/europa/europa-banner-250x100.png">
+<img src="https://raw.githubusercontent.com/neocotic/europa-branding/main/assets/banner/node-europa/node-europa-banner-377x100.png" alt="Europa Node">
 ```
 
 Markdown:
 
 ``` markdown
-![](https://cdn.rawgit.com/neocotic/europa-branding/master/assets/banner/europa/europa-banner-250x100.png)
-![Europa Node](https://cdn.rawgit.com/neocotic/europa-branding/master/assets/banner/node-europa/node-europa-banner-377x100.png)
+![](https://raw.githubusercontent.com/neocotic/europa-branding/main/assets/banner/europa/europa-banner-250x100.png)
+![Europa Node](https://raw.githubusercontent.com/neocotic/europa-branding/main/assets/banner/node-europa/node-europa-banner-377x100.png)
 ```
 
 ## Bugs

--- a/packages/europa-test/README.md
+++ b/packages/europa-test/README.md
@@ -1,4 +1,4 @@
-![Europa Test](https://cdn.rawgit.com/neocotic/europa-branding/master/assets/banner/europa-test/europa-test-banner-710x200.png)
+![Europa Test](https://raw.githubusercontent.com/neocotic/europa-branding/main/assets/banner/europa-test/europa-test-banner-710x200.png)
 
 [Europa Test](https://github.com/neocotic/europa/tree/main/packages/europa-test) is a framework for testing
 [Europa Core](https://github.com/neocotic/europa/tree/main/packages/europa-core) implementations.

--- a/packages/europa/README.md
+++ b/packages/europa/README.md
@@ -1,4 +1,4 @@
-![Europa](https://cdn.rawgit.com/neocotic/europa-branding/master/assets/banner/europa/europa-banner-500x200.png)
+![Europa](https://raw.githubusercontent.com/neocotic/europa-branding/main/assets/banner/europa/europa-banner-500x200.png)
 
 [Europa](https://github.com/neocotic/europa) is a pure JavaScript library for converting HTML into valid Markdown.
 

--- a/packages/node-europa/README.md
+++ b/packages/node-europa/README.md
@@ -1,4 +1,4 @@
-![Europa Node](https://cdn.rawgit.com/neocotic/europa-branding/master/assets/banner/node-europa/node-europa-banner-754x200.png)
+![Europa Node](https://raw.githubusercontent.com/neocotic/europa-branding/main/assets/banner/node-europa/node-europa-banner-754x200.png)
 
 [Europa Node](https://github.com/neocotic/europa/tree/main/packages/node-europa) is a [Node.js](https://nodejs.org)
 module for converting HTML into valid Markdown.


### PR DESCRIPTION
The `europa-branding` repository has recently changed its default branch from `master` to `main`. While the `master` branch still remains to serve legacy references, we should change future releases to point at the latest assets in the `main` branch.

Additionally, with RawGit having been sunset for a long time now, GitHub's own CDN should be used to load the assets.