### PR TITLE
Fix build status shield on README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Europa](https://raw.githubusercontent.com/neocotic/europa-branding/main/assets/banner/europa/europa-banner-500x200.png)
 
-[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/main?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/neocotic/europa.svg?style=flat-square)](https://github.com/neocotic/europa/blob/main/LICENSE.md)
 [![Release](https://img.shields.io/github/release/neocotic/europa.svg?style=flat-square)](https://github.com/neocotic/europa)
 

--- a/packages/europa-build/README.md
+++ b/packages/europa-build/README.md
@@ -3,7 +3,7 @@
 [Europa Build](https://github.com/neocotic/europa/tree/main/packages/europa-build) is a tool for generating and
 maintaining [Europa](https://github.com/neocotic/europa) plugin and preset packages.
 
-[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/main?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/europa-build.svg?style=flat-square)](https://github.com/neocotic/europa/raw/main/packages/europa-build/LICENSE.md)
 [![Release](https://img.shields.io/npm/v/europa-build.svg?style=flat-square)](https://npmjs.com/package/europa-build)
 

--- a/packages/europa-core/README.md
+++ b/packages/europa-core/README.md
@@ -3,7 +3,7 @@
 [Europa Core](https://github.com/neocotic/europa/tree/main/packages/europa-core) is the core engine for
 [Europa](https://github.com/neocotic/europa)'s HTML to Markdown conversion.
 
-[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/main?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/europa-core.svg?style=flat-square)](https://github.com/neocotic/europa/raw/main/packages/europa-core/LICENSE.md)
 [![Release](https://img.shields.io/npm/v/europa-core.svg?style=flat-square)](https://npmjs.com/package/europa-core)
 

--- a/packages/europa-plugin-anchor/README.md
+++ b/packages/europa-plugin-anchor/README.md
@@ -2,7 +2,7 @@
 
 A [Europa](https://github.com/neocotic/europa) plugin to convert HTML tags to Markdown links.
 
-[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/main?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/europa-plugin-anchor.svg?style=flat-square)](https://github.com/neocotic/europa/raw/main/packages/europa-plugin-anchor/LICENSE.md)
 [![Release](https://img.shields.io/npm/v/europa-plugin-anchor.svg?style=flat-square)](https://npmjs.com/package/europa-plugin-anchor)
 

--- a/packages/europa-plugin-bold/README.md
+++ b/packages/europa-plugin-bold/README.md
@@ -2,7 +2,7 @@
 
 A [Europa](https://github.com/neocotic/europa) plugin to convert HTML tags to Markdown bold text.
 
-[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/main?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/europa-plugin-bold.svg?style=flat-square)](https://github.com/neocotic/europa/raw/main/packages/europa-plugin-bold/LICENSE.md)
 [![Release](https://img.shields.io/npm/v/europa-plugin-bold.svg?style=flat-square)](https://npmjs.com/package/europa-plugin-bold)
 

--- a/packages/europa-plugin-code/README.md
+++ b/packages/europa-plugin-code/README.md
@@ -2,7 +2,7 @@
 
 A [Europa](https://github.com/neocotic/europa) plugin to convert HTML tags to Markdown inline code.
 
-[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/main?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/europa-plugin-code.svg?style=flat-square)](https://github.com/neocotic/europa/raw/main/packages/europa-plugin-code/LICENSE.md)
 [![Release](https://img.shields.io/npm/v/europa-plugin-code.svg?style=flat-square)](https://npmjs.com/package/europa-plugin-code)
 

--- a/packages/europa-plugin-description/README.md
+++ b/packages/europa-plugin-description/README.md
@@ -2,7 +2,7 @@
 
 A [Europa](https://github.com/neocotic/europa) plugin to convert HTML description list tags to Markdown.
 
-[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/main?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/europa-plugin-description.svg?style=flat-square)](https://github.com/neocotic/europa/raw/main/packages/europa-plugin-description/LICENSE.md)
 [![Release](https://img.shields.io/npm/v/europa-plugin-description.svg?style=flat-square)](https://npmjs.com/package/europa-plugin-description)
 

--- a/packages/europa-plugin-details/README.md
+++ b/packages/europa-plugin-details/README.md
@@ -2,7 +2,7 @@
 
 A [Europa](https://github.com/neocotic/europa) plugin to convert HTML details tags to Markdown.
 
-[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/main?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/europa-plugin-details.svg?style=flat-square)](https://github.com/neocotic/europa/raw/main/packages/europa-plugin-details/LICENSE.md)
 [![Release](https://img.shields.io/npm/v/europa-plugin-details.svg?style=flat-square)](https://npmjs.com/package/europa-plugin-details)
 

--- a/packages/europa-plugin-frame/README.md
+++ b/packages/europa-plugin-frame/README.md
@@ -2,7 +2,7 @@
 
 A [Europa](https://github.com/neocotic/europa) plugin to convert HTML frame tags to Markdown.
 
-[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/main?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/europa-plugin-frame.svg?style=flat-square)](https://github.com/neocotic/europa/raw/main/packages/europa-plugin-frame/LICENSE.md)
 [![Release](https://img.shields.io/npm/v/europa-plugin-frame.svg?style=flat-square)](https://npmjs.com/package/europa-plugin-frame)
 

--- a/packages/europa-plugin-header/README.md
+++ b/packages/europa-plugin-header/README.md
@@ -2,7 +2,7 @@
 
 A [Europa](https://github.com/neocotic/europa) plugin to convert HTML tags to Markdown headers.
 
-[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/main?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/europa-plugin-header.svg?style=flat-square)](https://github.com/neocotic/europa/raw/main/packages/europa-plugin-header/LICENSE.md)
 [![Release](https://img.shields.io/npm/v/europa-plugin-header.svg?style=flat-square)](https://npmjs.com/package/europa-plugin-header)
 

--- a/packages/europa-plugin-horizontal-rule/README.md
+++ b/packages/europa-plugin-horizontal-rule/README.md
@@ -2,7 +2,7 @@
 
 A [Europa](https://github.com/neocotic/europa) plugin to convert HTML tags to Markdown horizontal rules.
 
-[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/main?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/europa-plugin-horizontal-rule.svg?style=flat-square)](https://github.com/neocotic/europa/raw/main/packages/europa-plugin-horizontal-rule/LICENSE.md)
 [![Release](https://img.shields.io/npm/v/europa-plugin-horizontal-rule.svg?style=flat-square)](https://npmjs.com/package/europa-plugin-horizontal-rule)
 

--- a/packages/europa-plugin-image/README.md
+++ b/packages/europa-plugin-image/README.md
@@ -2,7 +2,7 @@
 
 A [Europa](https://github.com/neocotic/europa) plugin to convert HTML tags to Markdown images.
 
-[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/main?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/europa-plugin-image.svg?style=flat-square)](https://github.com/neocotic/europa/raw/main/packages/europa-plugin-image/LICENSE.md)
 [![Release](https://img.shields.io/npm/v/europa-plugin-image.svg?style=flat-square)](https://npmjs.com/package/europa-plugin-image)
 

--- a/packages/europa-plugin-italic/README.md
+++ b/packages/europa-plugin-italic/README.md
@@ -2,7 +2,7 @@
 
 A [Europa](https://github.com/neocotic/europa) plugin to convert HTML tags to Markdown italic text.
 
-[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/main?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/europa-plugin-italic.svg?style=flat-square)](https://github.com/neocotic/europa/raw/main/packages/europa-plugin-italic/LICENSE.md)
 [![Release](https://img.shields.io/npm/v/europa-plugin-italic.svg?style=flat-square)](https://npmjs.com/package/europa-plugin-italic)
 

--- a/packages/europa-plugin-line-break/README.md
+++ b/packages/europa-plugin-line-break/README.md
@@ -2,7 +2,7 @@
 
 A [Europa](https://github.com/neocotic/europa) plugin to convert HTML tags to Markdown line breaks.
 
-[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/main?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/europa-plugin-line-break.svg?style=flat-square)](https://github.com/neocotic/europa/raw/main/packages/europa-plugin-line-break/LICENSE.md)
 [![Release](https://img.shields.io/npm/v/europa-plugin-line-break.svg?style=flat-square)](https://npmjs.com/package/europa-plugin-line-break)
 

--- a/packages/europa-plugin-list/README.md
+++ b/packages/europa-plugin-list/README.md
@@ -2,7 +2,7 @@
 
 A [Europa](https://github.com/neocotic/europa) plugin to convert HTML tags to Markdown lists.
 
-[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/main?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/europa-plugin-list.svg?style=flat-square)](https://github.com/neocotic/europa/raw/main/packages/europa-plugin-list/LICENSE.md)
 [![Release](https://img.shields.io/npm/v/europa-plugin-list.svg?style=flat-square)](https://npmjs.com/package/europa-plugin-list)
 

--- a/packages/europa-plugin-paragraph/README.md
+++ b/packages/europa-plugin-paragraph/README.md
@@ -2,7 +2,7 @@
 
 A [Europa](https://github.com/neocotic/europa) plugin to convert HTML tags to Markdown paragraphs.
 
-[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/main?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/europa-plugin-paragraph.svg?style=flat-square)](https://github.com/neocotic/europa/raw/main/packages/europa-plugin-paragraph/LICENSE.md)
 [![Release](https://img.shields.io/npm/v/europa-plugin-paragraph.svg?style=flat-square)](https://npmjs.com/package/europa-plugin-paragraph)
 

--- a/packages/europa-plugin-preformatted/README.md
+++ b/packages/europa-plugin-preformatted/README.md
@@ -2,7 +2,7 @@
 
 A [Europa](https://github.com/neocotic/europa) plugin to convert HTML tags to Markdown preformatted blocks.
 
-[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/main?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/europa-plugin-preformatted.svg?style=flat-square)](https://github.com/neocotic/europa/raw/main/packages/europa-plugin-preformatted/LICENSE.md)
 [![Release](https://img.shields.io/npm/v/europa-plugin-preformatted.svg?style=flat-square)](https://npmjs.com/package/europa-plugin-preformatted)
 

--- a/packages/europa-plugin-quote/README.md
+++ b/packages/europa-plugin-quote/README.md
@@ -2,7 +2,7 @@
 
 A [Europa](https://github.com/neocotic/europa) plugin to convert HTML tags to Markdown quotes.
 
-[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/main?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/europa-plugin-quote.svg?style=flat-square)](https://github.com/neocotic/europa/raw/main/packages/europa-plugin-quote/LICENSE.md)
 [![Release](https://img.shields.io/npm/v/europa-plugin-quote.svg?style=flat-square)](https://npmjs.com/package/europa-plugin-quote)
 

--- a/packages/europa-preset-default/README.md
+++ b/packages/europa-preset-default/README.md
@@ -2,7 +2,7 @@
 
 The default [Europa](https://github.com/neocotic/europa) preset.
 
-[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/main?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/europa-preset-default.svg?style=flat-square)](https://github.com/neocotic/europa/raw/main/packages/europa-preset-default/LICENSE.md)
 [![Release](https://img.shields.io/npm/v/europa-preset-default.svg?style=flat-square)](https://npmjs.com/package/europa-preset-default)
 

--- a/packages/europa-test/README.md
+++ b/packages/europa-test/README.md
@@ -3,7 +3,7 @@
 [Europa Test](https://github.com/neocotic/europa/tree/main/packages/europa-test) is a framework for testing
 [Europa Core](https://github.com/neocotic/europa/tree/main/packages/europa-core) implementations.
 
-[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/main?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/europa-test.svg?style=flat-square)](https://github.com/neocotic/europa/raw/main/packages/europa-test/LICENSE.md)
 [![Release](https://img.shields.io/npm/v/europa-test.svg?style=flat-square)](https://npmjs.com/package/europa-test)
 

--- a/packages/europa/README.md
+++ b/packages/europa/README.md
@@ -3,7 +3,7 @@
 [Europa](https://github.com/neocotic/europa) is a pure JavaScript library for converting HTML into valid Markdown.
 
 [![Demo](https://img.shields.io/badge/demo-live-brightgreen.svg?style=flat-square)](https://codepen.io/neocotic/pen/YzeKvzG)
-[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/main?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/europa.svg?style=flat-square)](https://github.com/neocotic/europa/raw/main/packages/europa/LICENSE.md)
 [![Release](https://img.shields.io/npm/v/europa.svg?style=flat-square)](https://npmjs.com/package/europa)
 

--- a/packages/node-europa/README.md
+++ b/packages/node-europa/README.md
@@ -3,7 +3,7 @@
 [Europa Node](https://github.com/neocotic/europa/tree/main/packages/node-europa) is a [Node.js](https://nodejs.org)
 module for converting HTML into valid Markdown.
 
-[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/develop?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/workflow/status/neocotic/europa/CI/main?style=flat-square)](https://github.com/neocotic/europa/actions/workflows/ci.yml)
 [![License](https://img.shields.io/npm/l/node-europa.svg?style=flat-square)](https://github.com/neocotic/europa/raw/main/packages/node-europa/LICENSE.md)
 [![Release](https://img.shields.io/npm/v/node-europa.svg?style=flat-square)](https://npmjs.com/package/node-europa)
 


### PR DESCRIPTION
The build status shield on all `README.md` files was referencing the `develop` branch, which has been abandoned. All the build status shields now correctly reference the `main` branch.