### PR TITLE
Simplify recording references

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "lerna run lint --stream",
     "publish:packages": "lerna publish from-package",
     "test": "lerna run test --stream",
-    "verify": "npm run format && npm run build && npm run bootstrap && npm run flint && npm test",
+    "verify": "npm run format && npm run build && npm run bootstrap && npm run lint && npm test",
     "version:packages": "lerna version --no-git-tag-version --no-push"
   }
 }

--- a/packages/europa-plugin-image/src/index.ts
+++ b/packages/europa-plugin-image/src/index.ts
@@ -23,10 +23,8 @@
 import { Plugin } from 'europa-core';
 
 export default function (): Plugin {
-  const pluginName = 'europa-plugin-image';
-
   return {
-    name: pluginName,
+    name: 'europa-plugin-image',
 
     converters: {
       IMG: {
@@ -39,22 +37,15 @@ export default function (): Plugin {
           }
 
           const alternativeText = element.getAttribute('alt') || '';
-          const { imageMap, images } = conversion.context[pluginName] as ImagePluginContext;
           const title = element.getAttribute('title');
           let value = title ? `${source} "${title}"` : source;
-          let index;
 
           if (options.inline) {
             value = `(${value})`;
           } else {
-            index = imageMap[value];
-            if (index == null) {
-              index = images.push(value);
+            const reference = conversion.addReference('image', value);
 
-              imageMap[value] = index;
-            }
-
-            value = `[image${index}]`;
+            value = `[${reference}]`;
           }
 
           conversion.output(`![${alternativeText}]${value}`);
@@ -63,30 +54,5 @@ export default function (): Plugin {
         },
       },
     },
-
-    startConversion(conversion) {
-      conversion.context[pluginName] = {
-        imageMap: {},
-        images: [],
-      };
-    },
-
-    endConversion(conversion) {
-      const { images } = conversion.context[pluginName] as ImagePluginContext;
-      if (!images.length) {
-        return;
-      }
-
-      conversion.append(`${conversion.eol}${conversion.eol}`);
-
-      for (let i = 0; i < images.length; i++) {
-        conversion.append(`[image${i + 1}]: ${images[i]}${conversion.eol}`);
-      }
-    },
   };
 }
-
-type ImagePluginContext = {
-  readonly imageMap: Record<string, number>;
-  readonly images: string[];
-};

--- a/packages/europa-plugin-link/src/index.ts
+++ b/packages/europa-plugin-link/src/index.ts
@@ -23,10 +23,8 @@
 import { Plugin } from 'europa-core';
 
 export default function (): Plugin {
-  const pluginName = 'europa-plugin-link';
-
   return {
-    name: pluginName,
+    name: 'europa-plugin-link',
 
     converters: {
       A: {
@@ -38,22 +36,15 @@ export default function (): Plugin {
             return true;
           }
 
-          const { linkMap, links } = conversion.context[pluginName] as LinkPluginContext;
           const title = element.getAttribute('title');
           const value = title ? `${href} "${title}"` : href;
-          let index;
 
           if (inline) {
             context.value = `(${value})`;
           } else {
-            index = linkMap[value];
-            if (index == null) {
-              index = links.push(value);
+            const reference = conversion.addReference('link', value);
 
-              linkMap[value] = index;
-            }
-
-            context.value = `[link${index}]`;
+            context.value = `[${reference}]`;
           }
 
           conversion.output('[');
@@ -70,30 +61,5 @@ export default function (): Plugin {
         },
       },
     },
-
-    startConversion(conversion) {
-      conversion.context[pluginName] = {
-        linkMap: {},
-        links: [],
-      };
-    },
-
-    endConversion(conversion) {
-      const { links } = conversion.context[pluginName] as LinkPluginContext;
-      if (!links.length) {
-        return;
-      }
-
-      conversion.append(`${conversion.eol}${conversion.eol}`);
-
-      for (let i = 0; i < links.length; i++) {
-        conversion.append(`[link${i + 1}]: ${links[i]}${conversion.eol}`);
-      }
-    },
   };
 }
-
-type LinkPluginContext = {
-  readonly linkMap: Record<string, number>;
-  readonly links: string[];
-};

--- a/packages/europa-test/fixtures/content.html
+++ b/packages/europa-test/fixtures/content.html
@@ -59,18 +59,18 @@
   <img alt="image with no src">
   <a>link with no href</a>
   <a title="mock">link with title but no href</a>
-  <a href="mock1">link with href 1</a>
-  <a href="mock1" title="mock1">link with href 1 and title 1</a>
-  <a href="mock1" title="mock1">link with href 1 and title 1 (duplicate)</a>
-  <a href="mock1" title="mock2">link with href 1 and title 2</a>
-  <a href="mock1">link with href 1 (duplicate)</a>
-  <a href="mock2">link with href 2</a>
-  <a href="mock2" title="mock1">link with href 2 and title 1</a>
-  <a href="mock2" title="mock2">link with href 2 and title 2</a>
-  <a href="mock2">link with href 2 (duplicate)</a>
+  <a href="path/1">link with href 1</a>
+  <a href="path/1" title="link with title 1">link with href 1 and title 1</a>
+  <a href="path/1" title="link with title 1">link with href 1 and title 1 (duplicate)</a>
+  <a href="path/1" title="link with title 2">link with href 1 and title 2</a>
+  <a href="path/1">link with href 1 (duplicate)</a>
+  <a href="path/2">link with href 2</a>
+  <a href="path/2" title="link with title 1">link with href 2 and title 1</a>
+  <a href="path/2" title="link with title 2">link with href 2 and title 2</a>
+  <a href="path/2">link with href 2 (duplicate)</a>
   <a href="http://europa.mock"></a>
-  <a href="http://europa.mock" title="mock"></a>
-  <a href="mock1"><strong><em>link with href 1 and bold italic content</em></strong></a>
-  <a href="mock1"><img alt="image in link" src="image-in-link.png">link with href 1 and image content</a>
+  <a href="http://europa.mock" title="link with title 1"></a>
+  <a href="path/1"><strong><em>link with href 1 and bold italic content</em></strong></a>
+  <a href="path/1"><img alt="image in link" src="image-in-link.png">link with href 1 and image content</a>
 </body>
 </html>

--- a/packages/europa-test/fixtures/content.md
+++ b/packages/europa-test/fixtures/content.md
@@ -77,13 +77,11 @@ link with title but no href
 [image3]: image-with-title-1.png "image with title 1"
 [image4]: http://europa.mock/image.png
 [image5]: image-in-link.png
-
-
-[link1]: mock1
-[link2]: mock1 "mock1"
-[link3]: mock1 "mock2"
-[link4]: mock2
-[link5]: mock2 "mock1"
-[link6]: mock2 "mock2"
+[link1]: path/1
+[link2]: path/1 "link with title 1"
+[link3]: path/1 "link with title 2"
+[link4]: path/2
+[link5]: path/2 "link with title 1"
+[link6]: path/2 "link with title 2"
 [link7]: http://europa.mock
-[link8]: http://europa.mock "mock"
+[link8]: http://europa.mock "link with title 1"


### PR DESCRIPTION
The `europa-plugin-image` and `europa-plugin-link` packages shared a lot of logic relating to the recording and rendering of Markdown references at the end of the output.

A `Conversion#addReference` method has been added to drastically simplify this and the `Conversion#end` method now ensures any record references are rendered. The new method must only be called when the `inline` option is disabled.