### PR TITLE
Remove plugin and preset names

### DIFF
--- a/packages/europa-build/templates/plugin/.common/src/index.ts.mustache
+++ b/packages/europa-build/templates/plugin/.common/src/index.ts.mustache
@@ -4,33 +4,27 @@ import { Plugin, PluginApi } from 'europa-core';
 
 export default function (api: PluginApi): Plugin {
   return {
-    name: '{{name}}',
-
-    // This method can be removed if this plugin offers no converters or expanded to support more tags, if needed
+    // TODO: Add any tag converters or remove field if this plugin offers no converters
     converters: {
-      // TODO: Rename `TAGNAME` to the HTML tag name that is desired to be converted
+      // TODO: Rename `TAGNAME` to any HTML tag name that is desired to be converted
       TAGNAME: {
-        // This method can be removed if this plugin does not need to hook into the start of conversion for this tag
         startTag(conversion, context): boolean {
-          // TODO: Complete
+          // TODO: Complete or remove method if this plugin does not need to hook into the start of conversion for this tag
           return true;
         },
 
-        // This method can be removed if this plugin does not need to hook into the end of conversion for this tag
         endTag(conversion, context) {
-          // TODO: Complete
+          // TODO: Complete or remove method if this plugin does not need to hook into the end of conversion for this tag
         },
       },
     },
 
-    // This method can be removed if this plugin does not need to hook into the start of conversion
     startConversion(conversion) {
-      // TODO: Complete
+      // TODO: Complete or remove method if this plugin does not need to hook into the start of conversion
     },
 
-    // This method can be removed if this plugin does not need to hook into the end of conversion
     endConversion(conversion) {
-      // TODO: Complete
+      // TODO: Complete or remove method if this plugin does not need to hook into the end of conversion
     },
   };
 }

--- a/packages/europa-build/templates/preset/.common/src/index.ts.mustache
+++ b/packages/europa-build/templates/preset/.common/src/index.ts.mustache
@@ -8,8 +8,6 @@ const pluginProviders: PluginProvider[] = [
 
 export default function (api: PluginApi): Preset {
   return {
-    name: '{{name}}',
-
     plugins: pluginProviders.map((pluginProvider) => pluginProvider(api)),
   };
 }

--- a/packages/europa-core/src/plugin/Plugin.ts
+++ b/packages/europa-core/src/plugin/Plugin.ts
@@ -31,10 +31,6 @@ import { PluginApi } from 'europa-core/plugin/PluginApi';
  */
 export interface Plugin {
   /**
-   * The name of this {@link Plugin}.
-   */
-  readonly name: string;
-  /**
    * A map containing tag name to converter pairs.
    */
   readonly converters?: { readonly [key: string]: PluginConverter };

--- a/packages/europa-core/src/plugin/Preset.ts
+++ b/packages/europa-core/src/plugin/Preset.ts
@@ -28,10 +28,6 @@ import { PluginApi } from 'europa-core/plugin/PluginApi';
  */
 export interface Preset {
   /**
-   * The name of this plugin preset.
-   */
-  readonly name: string;
-  /**
    * The plugins that belong to this preset.
    */
   readonly plugins?: Plugin[];

--- a/packages/europa-plugin-bold/src/index.ts
+++ b/packages/europa-plugin-bold/src/index.ts
@@ -26,8 +26,6 @@ export default function (api: PluginApi): Plugin {
   const boldConverter = api.createBoldConverter();
 
   return {
-    name: 'europa-plugin-bold',
-
     converters: {
       B: boldConverter,
       STRONG: boldConverter,

--- a/packages/europa-plugin-code/src/index.ts
+++ b/packages/europa-plugin-code/src/index.ts
@@ -48,8 +48,6 @@ export default function (): Plugin {
   };
 
   return {
-    name: 'europa-plugin-code',
-
     converters: {
       CODE: codeConverter,
       KBD: codeConverter,

--- a/packages/europa-plugin-description/src/index.ts
+++ b/packages/europa-plugin-description/src/index.ts
@@ -24,8 +24,6 @@ import { Plugin, PluginApi } from 'europa-core';
 
 export default function (api: PluginApi): Plugin {
   return {
-    name: 'europa-plugin-description',
-
     converters: {
       DD: api.createBlockQuoteConverter(),
       DT: {

--- a/packages/europa-plugin-details/src/index.ts
+++ b/packages/europa-plugin-details/src/index.ts
@@ -24,8 +24,6 @@ import { Plugin } from 'europa-core';
 
 export default function (): Plugin {
   return {
-    name: 'europa-plugin-details',
-
     converters: {
       DETAILS: {
         startTag(conversion, context): boolean {

--- a/packages/europa-plugin-frame/src/index.ts
+++ b/packages/europa-plugin-frame/src/index.ts
@@ -44,8 +44,6 @@ export default function (): Plugin {
   };
 
   return {
-    name: 'europa-plugin-frame',
-
     converters: {
       FRAME: frameConverter,
       IFRAME: frameConverter,

--- a/packages/europa-plugin-header/src/index.ts
+++ b/packages/europa-plugin-header/src/index.ts
@@ -41,8 +41,6 @@ export default function (): Plugin {
   };
 
   return {
-    name: 'europa-plugin-header',
-
     converters: {
       H1: headingConverter,
       H2: headingConverter,

--- a/packages/europa-plugin-horizontal-rule/src/index.ts
+++ b/packages/europa-plugin-horizontal-rule/src/index.ts
@@ -24,8 +24,6 @@ import { Plugin } from 'europa-core';
 
 export default function (): Plugin {
   return {
-    name: 'europa-plugin-horizontal-rule',
-
     converters: {
       HR: {
         startTag(conversion) {

--- a/packages/europa-plugin-image/src/index.ts
+++ b/packages/europa-plugin-image/src/index.ts
@@ -24,8 +24,6 @@ import { Plugin } from 'europa-core';
 
 export default function (): Plugin {
   return {
-    name: 'europa-plugin-image',
-
     converters: {
       IMG: {
         startTag(conversion) {

--- a/packages/europa-plugin-italic/src/index.ts
+++ b/packages/europa-plugin-italic/src/index.ts
@@ -26,8 +26,6 @@ export default function (api: PluginApi): Plugin {
   const italicConverter = api.createItalicConverter();
 
   return {
-    name: 'europa-plugin-italic',
-
     converters: {
       CITE: italicConverter,
       DFN: italicConverter,

--- a/packages/europa-plugin-line-break/src/index.ts
+++ b/packages/europa-plugin-line-break/src/index.ts
@@ -24,8 +24,6 @@ import { Plugin } from 'europa-core';
 
 export default function (): Plugin {
   return {
-    name: 'europa-plugin-line-break',
-
     converters: {
       BR: {
         startTag(conversion): boolean {

--- a/packages/europa-plugin-link/src/index.ts
+++ b/packages/europa-plugin-link/src/index.ts
@@ -24,8 +24,6 @@ import { Plugin } from 'europa-core';
 
 export default function (): Plugin {
   return {
-    name: 'europa-plugin-link',
-
     converters: {
       A: {
         startTag(conversion, context): boolean {

--- a/packages/europa-plugin-list/src/index.ts
+++ b/packages/europa-plugin-list/src/index.ts
@@ -24,8 +24,6 @@ import { Plugin, PluginApi, PluginConverter } from 'europa-core';
 
 export default function (api: PluginApi): Plugin {
   return {
-    name: 'europa-plugin-list',
-
     converters: {
       LI: {
         startTag(conversion) {

--- a/packages/europa-plugin-paragraph/src/index.ts
+++ b/packages/europa-plugin-paragraph/src/index.ts
@@ -32,8 +32,6 @@ export default function (): Plugin {
   };
 
   return {
-    name: 'europa-plugin-paragraph',
-
     converters: {
       ADDRESS: paragraphConverter,
       ARTICLE: paragraphConverter,

--- a/packages/europa-plugin-preformatted/src/index.ts
+++ b/packages/europa-plugin-preformatted/src/index.ts
@@ -24,8 +24,6 @@ import { Plugin } from 'europa-core';
 
 export default function (): Plugin {
   return {
-    name: 'europa-plugin-preformatted',
-
     converters: {
       PRE: {
         startTag(conversion, context) {

--- a/packages/europa-plugin-quote/src/index.ts
+++ b/packages/europa-plugin-quote/src/index.ts
@@ -24,8 +24,6 @@ import { Plugin, PluginApi } from 'europa-core';
 
 export default function (api: PluginApi): Plugin {
   return {
-    name: 'europa-plugin-quote',
-
     converters: {
       BLOCKQUOTE: api.createBlockQuoteConverter(),
       Q: {

--- a/packages/europa-preset-default/src/index.ts
+++ b/packages/europa-preset-default/src/index.ts
@@ -57,8 +57,6 @@ const pluginProviders: PluginProvider[] = [
 
 export default function (api: PluginApi): Preset {
   return {
-    name: 'europa-preset-default',
-
     plugins: pluginProviders.map((pluginProvider) => pluginProvider(api)),
   };
 }

--- a/packages/europa/README.md
+++ b/packages/europa/README.md
@@ -113,8 +113,7 @@ you can really do:
 
 ``` javascript
 Europa.registerPlugin((api) => ({
-  name: 'europa-plugin-example',
-  // Everything below is optional
+  // All fields and methods are optional
   converters: {
     TAGNAME: {
       startTag(conversion, context) { /* ... */ },
@@ -152,7 +151,6 @@ const pluginProviders = [
 ];
 
 Europa.registerPreset((api) => ({
-  name: 'europa-preset-example',
   plugins: pluginProviders.map((pluginProvider) => pluginProvider(api)),
 }));
 ```

--- a/packages/node-europa/README.md
+++ b/packages/node-europa/README.md
@@ -134,8 +134,7 @@ you can really do:
 
 ``` javascript
 Europa.registerPlugin((api) => ({
-  name: 'europa-plugin-example',
-  // Everything below is optional
+  // All fields and methods are optional
   converters: {
     TAGNAME: {
       startTag(conversion, context) { /* ... */ },
@@ -173,7 +172,6 @@ const pluginProviders = [
 ];
 
 Europa.registerPreset((api) => ({
-  name: 'europa-preset-example',
   plugins: pluginProviders.map((pluginProvider) => pluginProvider(api)),
 }));
 ```


### PR DESCRIPTION
The concept of having plugin and preset package's export their names was needless. The name is never referenced or used and just adds bloat to bundled Europa Core implementations as the name strings cannot be compressed.

These have now been removed and `europa-build` has been updated to ensure any newly generated plugins/presets do not contain this field.