### PR TITLE
Remove descriptions from symbols

### DIFF
--- a/packages/europa-build/src/Cli.ts
+++ b/packages/europa-build/src/Cli.ts
@@ -31,11 +31,11 @@ import { TemplateManager } from 'europa-build/template/TemplateManager';
 import { TemplateCliOption, TemplateContext, TemplateProvider } from 'europa-build/template/provider/TemplateProvider';
 import { TemplateProviderType } from 'europa-build/template/provider/TemplateProviderType';
 
-const _cwd = Symbol('cwd');
-const _command = Symbol('command');
-const _logger = Symbol('logger');
-const _onError = Symbol('onError');
-const _outputStream = Symbol('outputStream');
+const _cwd = Symbol();
+const _command = Symbol();
+const _logger = Symbol();
+const _onError = Symbol();
+const _outputStream = Symbol();
 
 /**
  * A command-line interface for generating and maintaining Europa plugins and presets.

--- a/packages/europa-build/src/PackageInfo.ts
+++ b/packages/europa-build/src/PackageInfo.ts
@@ -23,7 +23,7 @@
 import { dirname } from 'path';
 import * as readPkgUp from 'read-pkg-up';
 
-const _singleton = Symbol('singleton');
+const _singleton = Symbol();
 
 /**
  * Contains information relating to this npm package, including its installation location.

--- a/packages/europa-build/src/script/ScriptRunner.ts
+++ b/packages/europa-build/src/script/ScriptRunner.ts
@@ -30,8 +30,8 @@ import { LintScriptProvider } from 'europa-build/script/provider/LintScriptProvi
 import { ScriptProvider } from 'europa-build/script/provider/ScriptProvider';
 import { TestScriptProvider } from 'europa-build/script/provider/TestScriptProvider';
 
-const _logger = Symbol('logger');
-const _providers = Symbol('providers');
+const _logger = Symbol();
+const _providers = Symbol();
 
 /**
  * A runner for scripts that relate to generated plugin and preset packages.

--- a/packages/europa-build/src/script/provider/CommonScriptProvider.ts
+++ b/packages/europa-build/src/script/provider/CommonScriptProvider.ts
@@ -28,7 +28,7 @@ import { Logger } from 'winston';
 import { PackageInfo } from 'europa-build/PackageInfo';
 import { ScriptProvider } from 'europa-build/script/provider/ScriptProvider';
 
-const _logger = Symbol('logger');
+const _logger = Symbol();
 
 /**
  * An abstract {@link ScriptProvider} that provides common logic across the majority of implementations.

--- a/packages/europa-build/src/template/MustacheTemplateGenerator.ts
+++ b/packages/europa-build/src/template/MustacheTemplateGenerator.ts
@@ -32,9 +32,9 @@ import { PackageInfo } from 'europa-build/PackageInfo';
 import { TemplateGenerator } from 'europa-build/template/TemplateGenerator';
 import { TemplateContext, TemplateProvider } from 'europa-build/template/provider/TemplateProvider';
 
-const _logger = Symbol('logger');
-const _partials = Symbol('partials');
-const _provider = Symbol('provider');
+const _logger = Symbol();
+const _partials = Symbol();
+const _provider = Symbol();
 
 /**
  * A {@link TemplateGenerator} implementation that uses Mustache to render templates.

--- a/packages/europa-build/src/template/TemplateManager.ts
+++ b/packages/europa-build/src/template/TemplateManager.ts
@@ -30,8 +30,8 @@ import { OfficialPluginTemplateProvider } from 'europa-build/template/provider/p
 import { ContribPresetTemplateProvider } from 'europa-build/template/provider/preset/ContribPresetTemplateProvider';
 import { OfficialPresetTemplateProvider } from 'europa-build/template/provider/preset/OfficialPresetTemplateProvider';
 
-const _logger = Symbol('logger');
-const _providers = Symbol('providers');
+const _logger = Symbol();
+const _providers = Symbol();
 
 /**
  * A basic manager for template providers that are mapped to their general names and types.

--- a/packages/europa-build/src/template/provider/CommonTemplateProvider.ts
+++ b/packages/europa-build/src/template/provider/CommonTemplateProvider.ts
@@ -27,7 +27,7 @@ import { TemplateGenerator } from 'europa-build/template/TemplateGenerator';
 import { TemplateCliOption, TemplateContext, TemplateProvider } from 'europa-build/template/provider/TemplateProvider';
 import { TemplateProviderType } from 'europa-build/template/provider/TemplateProviderType';
 
-const _parentLogger = Symbol('parentLogger');
+const _parentLogger = Symbol();
 
 /**
  * An abstract {@link TemplateProvider} that provides common logic that is useful for the majority of implementations.

--- a/packages/europa-cli/src/Cli.ts
+++ b/packages/europa-cli/src/Cli.ts
@@ -35,11 +35,11 @@ import { PackageInfo } from 'europa-cli/PackageInfo';
 
 const findFiles = promisify(glob);
 
-const _command = Symbol('command');
-const _cwd = Symbol('cwd');
-const _inputStream = Symbol('inputStream');
-const _onError = Symbol('onError');
-const _outputStream = Symbol('outputStream');
+const _command = Symbol();
+const _cwd = Symbol();
+const _inputStream = Symbol();
+const _onError = Symbol();
+const _outputStream = Symbol();
 
 /**
  * A command-line interface for converting HTML into Markdown.

--- a/packages/europa-cli/src/PackageInfo.ts
+++ b/packages/europa-cli/src/PackageInfo.ts
@@ -23,7 +23,7 @@
 import { dirname } from 'path';
 import * as readPkgUp from 'read-pkg-up';
 
-const _singleton = Symbol('singleton');
+const _singleton = Symbol();
 
 /**
  * Contains information relating to this npm package, including its installation location.

--- a/packages/europa-core/src/Conversion.ts
+++ b/packages/europa-core/src/Conversion.ts
@@ -24,16 +24,16 @@ import { Europa, EuropaOptions } from 'europa-core/Europa';
 import { ElementNode } from 'europa-core/dom/ElementNode';
 import { PluginManager } from 'europa-core/plugin/PluginManager';
 
-const _document = Symbol('document');
-const _element = Symbol('element');
-const _eol = Symbol('eol');
-const _europa = Symbol('europa');
-const _pluginManager = Symbol('pluginManager');
-const _referenceCache = Symbol('referenceCache');
-const _references = Symbol('references');
-const _skipTagNames = Symbol('skipTagNames');
-const _tagName = Symbol('tagName');
-const _window = Symbol('window');
+const _document = Symbol();
+const _element = Symbol();
+const _eol = Symbol();
+const _europa = Symbol();
+const _pluginManager = Symbol();
+const _referenceCache = Symbol();
+const _references = Symbol();
+const _skipTagNames = Symbol();
+const _tagName = Symbol();
+const _window = Symbol();
 
 /**
  * Contains contextual information for a single conversion process.

--- a/packages/europa-core/src/Europa.ts
+++ b/packages/europa-core/src/Europa.ts
@@ -29,10 +29,10 @@ import { Service } from 'europa-core/service/Service';
 import { ServiceManager } from 'europa-core/service/ServiceManager';
 import { ServiceName } from 'europa-core/service/ServiceName';
 
-const _options = Symbol('options');
-const _pluginManager = Symbol('pluginManager');
-const _serviceManager = Symbol('serviceManager');
-const _window = Symbol('window');
+const _options = Symbol();
+const _pluginManager = Symbol();
+const _serviceManager = Symbol();
+const _window = Symbol();
 
 /**
  * Enables configuration of an HTML to Markdown converter that supports HTML strings and DOM elements.

--- a/packages/europa-core/src/EuropaOptionsParser.ts
+++ b/packages/europa-core/src/EuropaOptionsParser.ts
@@ -23,7 +23,7 @@
 import { EuropaOptions } from 'europa-core/Europa';
 import { WindowService } from 'europa-core/service/window/WindowService';
 
-const _windowService = Symbol('windowService');
+const _windowService = Symbol();
 
 /**
  * A parser for {@link EuropaOptions} that provides null safety and supports default value resolution.

--- a/packages/europa-core/src/plugin/PluginManager.ts
+++ b/packages/europa-core/src/plugin/PluginManager.ts
@@ -25,10 +25,10 @@ import { Plugin, PluginConverter, PluginProvider } from 'europa-core/plugin/Plug
 import { PluginApi } from 'europa-core/plugin/PluginApi';
 import { PresetProvider } from 'europa-core/plugin/Preset';
 
-const _addProvidedPlugin = Symbol('addProvidedPlugin');
-const _api = Symbol('api');
-const _converters = Symbol('converters');
-const _plugins = Symbol('plugins');
+const _addProvidedPlugin = Symbol();
+const _api = Symbol();
+const _converters = Symbol();
+const _plugins = Symbol();
 
 /**
  * A basic manager for plugins and presets (collections of plugins) that can be hooked into {@link Europa}.

--- a/packages/europa-core/src/service/ServiceManager.ts
+++ b/packages/europa-core/src/service/ServiceManager.ts
@@ -25,7 +25,7 @@ import { ServiceName } from 'europa-core/service/ServiceName';
 import { CharsetService } from 'europa-core/service/charset/CharsetService';
 import { WindowService } from 'europa-core/service/window/WindowService';
 
-const _services = Symbol('services');
+const _services = Symbol();
 
 /**
  * A basic manager for {@link Service} implementations that are mapped to simple names.


### PR DESCRIPTION
While symbol descriptions can be useful when inspecting instances during debugging, they can also lead to discovery issues and, more importantly, they can bloat bundled packages since their strings cannot be compressed. This commit removes all symbol descriptions to resolve this.