### PR TITLE
Add new eol option

### DIFF
--- a/packages/europa-cli/README.md
+++ b/packages/europa-cli/README.md
@@ -54,14 +54,14 @@ $ europa index.html --output docs
     Usage: europa [options] [file ...]
 
     Options:
-
-      -h, --help            output usage information
       -V, --version         output the version number
       -a, --absolute        use absolute URLs for elements (e.g. anchors, images)
       -b, --base-uri <uri>  base URI for elements (e.g. anchors, images)
       -e, --eval <html>     evaluate HTML string
+      --eol <character>     end of line character
       -i, --inline          insert URLs for elements (e.g. anchors, images) inline
       -o, --output <path>   output directory (for files) or file (for eval/stdin)
+      -h, --help            display help for command
 
 ## Bugs
 

--- a/packages/europa-cli/src/Cli.ts
+++ b/packages/europa-cli/src/Cli.ts
@@ -106,6 +106,7 @@ export class Cli {
       .option('-a, --absolute', 'use absolute URLs for elements (e.g. anchors, images)')
       .option('-b, --base-uri <uri>', 'base URI for elements (e.g. anchors, images)')
       .option('-e, --eval <html>', 'evaluate HTML string')
+      .option('--eol <character>', 'end of line character')
       .option('-i, --inline', 'insert URLs for elements (e.g. anchors, images) inline')
       .option('-o, --output <path>', 'output directory (for files) or file (for eval/stdin)');
 

--- a/packages/europa-core/README.md
+++ b/packages/europa-core/README.md
@@ -44,9 +44,9 @@ import defaultPresetProvider from 'europa-preset-default';
 class ExampleEnvironment implements Environment<any, any> {
   getDefaultBaseUri(): string { /* ... */ }
 
-  getDom(): Dom<any, any, any> { /* ... */ }
+  getDefaultEndOfLineCharacter(): string { /* ... */ }
 
-  getEndOfLineCharacter(): string { /* ... */ }
+  getDom(): Dom<any, any, any> { /* ... */ }
 
   resolveUrl(baseUri: string, url: string): string { /* ... */ }
 }

--- a/packages/europa-core/src/Conversion.ts
+++ b/packages/europa-core/src/Conversion.ts
@@ -133,7 +133,7 @@ export class Conversion {
     this[_options] = europaOptions;
     this[_pluginManager] = pluginManager;
     this.element = element;
-    this.left = environment.getEndOfLineCharacter();
+    this.left = europaOptions.eol;
   }
 
   /**
@@ -421,7 +421,7 @@ export class Conversion {
    * The end of line character to be used by this {@link Conversion}.
    */
   get eol(): string {
-    return this[_environment].getEndOfLineCharacter();
+    return this[_options].eol;
   }
 
   /**

--- a/packages/europa-core/src/EuropaOptions.ts
+++ b/packages/europa-core/src/EuropaOptions.ts
@@ -34,6 +34,11 @@ export interface EuropaOptions {
    */
   readonly baseUri?: string;
   /**
+   * The end of line character to be inserted into generated Markdown. Defaults to an environment-specific end of line
+   * character.
+   */
+  readonly eol?: string;
+  /**
    * Whether URLs for elements (e.g. anchors, images) are to be inserted inline. Defaults to `false`.
    */
   readonly inline?: boolean;

--- a/packages/europa-core/src/EuropaOptionsParser.ts
+++ b/packages/europa-core/src/EuropaOptionsParser.ts
@@ -59,6 +59,7 @@ export class EuropaOptionsParser {
     const definitions: EuropaOptionDefinitions = {
       absolute: false,
       baseUri: () => this[_environment].getDefaultBaseUri(),
+      eol: () => this[_environment].getDefaultEndOfLineCharacter(),
       inline: false,
     };
 
@@ -78,7 +79,7 @@ export class EuropaOptionsParser {
  */
 export type EuropaOptionsParserOptions = {
   /**
-   * The {@link Environment} to be used to provide the default base URI, if needed.
+   * The {@link Environment} to be used to provide environment-specific defaults, if needed.
    */
   readonly environment: Environment<any, any>;
 };

--- a/packages/europa-core/src/environment/Environment.ts
+++ b/packages/europa-core/src/environment/Environment.ts
@@ -35,6 +35,13 @@ export interface Environment<N, E extends N> {
   getDefaultBaseUri(): string;
 
   /**
+   * Returns the default end of line character to be inserted into generated Markdown.
+   *
+   * @return The default end of line character.
+   */
+  getDefaultEndOfLineCharacter(): string;
+
+  /**
    * Returns the DOM wrapper to be used in this {@link Environment}.
    *
    * This method should always return the same {@link Dom} instance when called multiple times.
@@ -42,13 +49,6 @@ export interface Environment<N, E extends N> {
    * @return The {@link Dom}.
    */
   getDom(): Dom<N, E, DomRoot>;
-
-  /**
-   * Returns the end of line character to be inserted into generated Markdown.
-   *
-   * @return The end of line character.
-   */
-  getEndOfLineCharacter(): string;
 
   /**
    * Returns the specified `url` relative to the `baseUri` provided in a manner similar to that of a web browser

--- a/packages/europa-dom-cheerio/README.md
+++ b/packages/europa-dom-cheerio/README.md
@@ -38,11 +38,11 @@ class ExampleEnvironment implements Environment<AnyNode, Element> {
 
   getDefaultBaseUri(): string { /* ... */ }
 
+  getDefaultEndOfLineCharacter(): string { /* ... */ }
+
   getDom(): Dom<AnyNode, Element, CheerioDomRoot> {
     return this[_dom];
   }
-
-  getEndOfLineCharacter(): string { /* ... */ }
 
   resolveUrl(baseUri: string, url: string): string { /* ... */ }
 }

--- a/packages/europa-dom-web/README.md
+++ b/packages/europa-dom-web/README.md
@@ -37,11 +37,11 @@ class ExampleEnvironment implements Environment<Node, Element> {
 
   getDefaultBaseUri(): string { /* ... */ }
 
+  getDefaultEndOfLineCharacter(): string { /* ... */ }
+
   getDom(): Dom<Node, Element, WebDomRoot> {
     return this[_dom];
   }
-
-  getEndOfLineCharacter(): string { /* ... */ }
 
   resolveUrl(baseUri: string, url: string): string { /* ... */ }
 }

--- a/packages/europa-environment-node/src/NodeEnvironment.ts
+++ b/packages/europa-environment-node/src/NodeEnvironment.ts
@@ -37,12 +37,12 @@ export class NodeEnvironment implements Environment<AnyNode, Element> {
     return `file:///${process.cwd().replace(/\\/g, '/')}`;
   }
 
-  getDom(): Dom<AnyNode, Element, CheerioDomRoot> {
-    return this[_dom];
+  getDefaultEndOfLineCharacter(): string {
+    return EOL;
   }
 
-  getEndOfLineCharacter(): string {
-    return EOL;
+  getDom(): Dom<AnyNode, Element, CheerioDomRoot> {
+    return this[_dom];
   }
 
   resolveUrl(baseUri: string, url: string): string {

--- a/packages/europa-environment-web/src/WebEnvironment.ts
+++ b/packages/europa-environment-web/src/WebEnvironment.ts
@@ -35,12 +35,12 @@ export class WebEnvironment implements Environment<Node, Element> {
     return window.document.baseURI;
   }
 
-  getDom(): Dom<Node, Element, WebDomRoot> {
-    return this[_dom];
+  getDefaultEndOfLineCharacter(): string {
+    return '\n';
   }
 
-  getEndOfLineCharacter(): string {
-    return '\n';
+  getDom(): Dom<Node, Element, WebDomRoot> {
+    return this[_dom];
   }
 
   resolveUrl(baseUri: string, url: string): string {

--- a/packages/europa-environment-worker/src/WorkerEnvironment.ts
+++ b/packages/europa-environment-worker/src/WorkerEnvironment.ts
@@ -35,12 +35,12 @@ export class WorkerEnvironment implements Environment<AnyNode, Element> {
     return this.resolveUrl(location.href, '.');
   }
 
-  getDom(): Dom<AnyNode, Element, CheerioDomRoot> {
-    return this[_dom];
+  getDefaultEndOfLineCharacter(): string {
+    return '\n';
   }
 
-  getEndOfLineCharacter(): string {
-    return '\n';
+  getDom(): Dom<AnyNode, Element, CheerioDomRoot> {
+    return this[_dom];
   }
 
   resolveUrl(baseUri: string, url: string): string {

--- a/packages/europa-worker/README.md
+++ b/packages/europa-worker/README.md
@@ -43,16 +43,18 @@ europa.convert('<a href="https://github.com/neocotic/europa">Europa</a>');
 Simply create an instance of `Europa` and you've done most of the work. You can control many aspects of the HTML to
 Markdown conversion by passing the following options to the constructor:
 
-| Option   | Type    | Description                                                                         | Default                   |
-|----------|---------|-------------------------------------------------------------------------------------|---------------------------|
-| absolute | Boolean | Whether absolute URLs should be used for elements (e.g. anchors, images)            | `false`                   |
-| baseUri  | String  | The base URI used to resolve relative URLs used for elements (e.g. anchors, images) | Parent of `location.href` |
-| inline   | Boolean | Whether URLs for elements (e.g. anchors, images) are to be inserted inline          | `false`                   |
+| Option     | Type    | Description                                                                         | Default                   |
+|------------|---------|-------------------------------------------------------------------------------------|---------------------------|
+| `absolute` | Boolean | Whether absolute URLs should be used for elements (e.g. anchors, images)            | `false`                   |
+| `baseUri`  | String  | The base URI used to resolve relative URLs used for elements (e.g. anchors, images) | Parent of `location.href` |
+| `eol`      | String  | The end of line character to be inserted into generated Markdown                    | `"\n"`                    |
+| `inline`   | Boolean | Whether URLs for elements (e.g. anchors, images) are to be inserted inline          | `false`                   |
 
 ``` typescript
 const europa = new Europa({
   absolute: true,
   baseUri: 'https://example.com',
+  eol: '\r\n',
   inline: true,
 });
 ```

--- a/packages/europa/README.md
+++ b/packages/europa/README.md
@@ -66,16 +66,18 @@ Open up `demo.html` in your browser to play around a bit.
 Simply create an instance of `Europa` and you've done most of the work. You can control many aspects of the HTML to
 Markdown conversion by passing the following options to the constructor:
 
-| Option   | Type    | Description                                                                         | Default            |
-|----------|---------|-------------------------------------------------------------------------------------|--------------------|
-| absolute | Boolean | Whether absolute URLs should be used for elements (e.g. anchors, images)            | `false`            |
-| baseUri  | String  | The base URI used to resolve relative URLs used for elements (e.g. anchors, images) | `document.baseURI` |
-| inline   | Boolean | Whether URLs for elements (e.g. anchors, images) are to be inserted inline          | `false`            |
+| Option     | Type    | Description                                                                         | Default            |
+|------------|---------|-------------------------------------------------------------------------------------|--------------------|
+| `absolute` | Boolean | Whether absolute URLs should be used for elements (e.g. anchors, images)            | `false`            |
+| `baseUri`  | String  | The base URI used to resolve relative URLs used for elements (e.g. anchors, images) | `document.baseURI` |
+| `eol`      | String  | The end of line character to be inserted into generated Markdown                    | `"\n"`             |
+| `inline`   | Boolean | Whether URLs for elements (e.g. anchors, images) are to be inserted inline          | `false`            |
 
 ``` typescript
 const europa = new Europa({
   absolute: true,
   baseUri: 'https://example.com',
+  eol: '\r\n',
   inline: true,
 });
 ```

--- a/packages/node-europa/README.md
+++ b/packages/node-europa/README.md
@@ -53,16 +53,18 @@ app.listen(3000);
 Simply create an instance of `Europa` and you've done most of the work. You can control many aspects of the HTML to
 Markdown conversion by passing the following options to the constructor:
 
-| Option   | Type    | Description                                                                         | Default                   |
-|----------|---------|-------------------------------------------------------------------------------------|---------------------------|
-| absolute | Boolean | Whether absolute URLs should be used for elements (e.g. anchors, images)            | `false`                   |
-| baseUri  | String  | The base URI used to resolve relative URLs used for elements (e.g. anchors, images) | `file://${process.cwd()}` |
-| inline   | Boolean | Whether URLs for elements (e.g. anchors, images) are to be inserted inline          | `false`                   |
+| Option     | Type    | Description                                                                         | Default                   |
+|------------|---------|-------------------------------------------------------------------------------------|---------------------------|
+| `absolute` | Boolean | Whether absolute URLs should be used for elements (e.g. anchors, images)            | `false`                   |
+| `baseUri`  | String  | The base URI used to resolve relative URLs used for elements (e.g. anchors, images) | `file://${process.cwd()}` |
+| `eol`      | String  | The end of line character to be inserted into generated Markdown                    | `os.EOL`                  |
+| `inline`   | Boolean | Whether URLs for elements (e.g. anchors, images) are to be inserted inline          | `false`                   |
 
 ``` typescript
 const europa = new Europa({
   absolute: true,
   baseUri: 'https://example.com',
+  eol: '\r\n',
   inline: true,
 });
 ```


### PR DESCRIPTION
The end of line character used when generating Markdown has been driven by the environment; a web browser used `"\n"` while Node.js used `os.EOL`. As this may not always be desirable, these environment-specific values will now serve as defaults which can be easily overridden by a new `eol` Europa option (`--eol` for `europa-cli`) that is being added.