### PR TITLE
Release 6.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,23 @@
+## Version 6.0.0, 2022.05.27
+
+* Improve compatibility with Markdown standards
+* Completely refactor plugin and preset API
+* Move built-in plugins and default preset into separate packages
+* Add tests for all official plugins and presets
+* Change reference numbering for anchor and image tags to a one-based index
+* Rename anchor tag referencing from `anchorN` to `linkN`
+* Simplify reference management for plugins
+* Refactor options API to ensure immutability
+* Move plugin-specific text conversion and escape logic to plugins
+* Refactor internal environment management for Europa Core implementations and introduce DOM wrappers
+* Create **europa-worker** package to allow usage of Europa within a service/web worker
+* Add `eol` option to override the environment-specific end of line character
+* Create **europa-build** package to simplify generation and maintenance of plugin/preset packages
+* Include comments in generated TypeScript declaration files
+* Fix build status shields
+* **node-europa**: Replace `jsdom` with `cheerio`
+* **node-europa**: Move CLI into a new **europa-cli** package
+
 ## Version 5.0.1, 2022.05.06
 
 * Remove copyright header from build files

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,13 @@
 {
-  "version": "5.0.1",
+  "version": "6.0.0",
   "npmClient": "npm",
+  "command": {
+    "bootstrap": {
+      "npmClientArgs": [
+        "--legacy-peer-deps"
+      ]
+    }
+  },
   "packages": [
     "packages/*"
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,10 @@
 {
   "name": "europa-parent",
-  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "europa-parent",
-      "version": "5.0.1",
       "license": "MIT",
       "devDependencies": {
         "del-cli": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "europa-parent",
-  "version": "5.0.1",
   "private": true,
   "license": "MIT",
   "devDependencies": {
@@ -16,7 +15,8 @@
     "format": "lerna run format --stream",
     "generate:plugin": "./packages/europa-build/bin/europa-build generate-plugin official packages --preset=default",
     "generate:preset": "./packages/europa-build/bin/europa-build generate-preset official packages",
-    "install:clean": "npm run clean && npm install && npm run bootstrap && npm run build && npm run bootstrap",
+    "install:all": "npm install && npm run bootstrap",
+    "install:clean": "npm run clean && npm run install:all && npm run build && npm run bootstrap",
     "lint": "lerna run lint --stream",
     "publish:packages": "lerna publish from-package",
     "test": "lerna run test --stream",

--- a/packages/europa-build/package-lock.json
+++ b/packages/europa-build/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-build",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-build",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -3899,8 +3899,7 @@
 		"acorn-jsx": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"requires": {}
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
 		},
 		"acorn-walk": {
 			"version": "8.2.0",
@@ -4374,8 +4373,7 @@
 		"eslint-config-prettier": {
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-			"requires": {}
+			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q=="
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",

--- a/packages/europa-build/package.json
+++ b/packages/europa-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-build",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Tool for generating and maintaining Europa plugins and presets",
   "keywords": [
     "europa",

--- a/packages/europa-cli/package-lock.json
+++ b/packages/europa-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-cli",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-cli",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -146,19 +146,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/@eslint/eslintrc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -199,34 +186,6 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -261,34 +220,6 @@
 			"engines": {
 				"node": ">= 8"
 			}
-		},
-		"node_modules/@tsconfig/node10": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node12": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node14": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node16": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/@types/glob": {
 			"version": "7.2.0",
@@ -566,16 +497,6 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
-		"node_modules/acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -615,13 +536,6 @@
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
-		},
-		"node_modules/arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
@@ -772,13 +686,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"node_modules/create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -830,16 +737,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/dir-glob": {
@@ -2069,13 +1966,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2837,50 +2727,6 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/ts-node": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
-			"integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			},
-			"bin": {
-				"ts-node": "dist/bin.js",
-				"ts-node-cwd": "dist/bin-cwd.js",
-				"ts-node-esm": "dist/bin-esm.js",
-				"ts-node-script": "dist/bin-script.js",
-				"ts-node-transpile-only": "dist/bin-transpile.js",
-				"ts-script": "dist/bin-script-deprecated.js"
-			},
-			"peerDependencies": {
-				"@swc/core": ">=1.2.50",
-				"@swc/wasm": ">=1.2.50",
-				"@types/node": "*",
-				"typescript": ">=2.7"
-			},
-			"peerDependenciesMeta": {
-				"@swc/core": {
-					"optional": true
-				},
-				"@swc/wasm": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/tsconfig-paths": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz",
@@ -3009,13 +2855,6 @@
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
-		"node_modules/v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/validate-npm-package-license": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -3075,16 +2914,6 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"node_modules/yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6"
-			}
 		}
 	},
 	"dependencies": {
@@ -3162,16 +2991,6 @@
 				}
 			}
 		},
-		"@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			}
-		},
 		"@eslint/eslintrc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -3206,31 +3025,6 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"@jridgewell/resolve-uri": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
-			"dev": true,
-			"peer": true
-		},
-		"@jridgewell/sourcemap-codec": {
-			"version": "1.4.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
-			"dev": true,
-			"peer": true
-		},
-		"@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3256,34 +3050,6 @@
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
 			}
-		},
-		"@tsconfig/node10": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node12": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node14": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node16": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-			"dev": true,
-			"peer": true
 		},
 		"@types/glob": {
 			"version": "7.2.0",
@@ -3461,15 +3227,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
-			"requires": {}
-		},
-		"acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"ajv": {
 			"version": "6.12.6",
@@ -3497,13 +3255,6 @@
 			"requires": {
 				"color-convert": "^2.0.1"
 			}
-		},
-		"arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"peer": true
 		},
 		"argparse": {
 			"version": "2.0.1",
@@ -3618,13 +3369,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"peer": true
-		},
 		"cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3660,13 +3404,6 @@
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
 			}
-		},
-		"diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"peer": true
 		},
 		"dir-glob": {
 			"version": "3.0.1",
@@ -3816,8 +3553,7 @@
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
 			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",
@@ -4603,13 +4339,6 @@
 				"yallist": "^4.0.0"
 			}
 		},
-		"make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"peer": true
-		},
 		"merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5137,28 +4866,6 @@
 				"is-number": "^7.0.0"
 			}
 		},
-		"ts-node": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
-			"integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			}
-		},
 		"tsconfig-paths": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz",
@@ -5251,13 +4958,6 @@
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
-		"v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"peer": true
-		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -5305,13 +5005,6 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-cli/package.json
+++ b/packages/europa-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-cli",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "CLI for converting HTML into valid Markdown via Europa",
   "keywords": [
     "europa",
@@ -43,7 +43,7 @@
     "commander": "^9.2.0",
     "glob": "^8.0.1",
     "mkdirp": "^1.0.4",
-    "node-europa": "^5.0.1",
+    "node-europa": "^6.0.0",
     "read-pkg-up": "^7.0.1"
   },
   "devDependencies": {

--- a/packages/europa-core/package-lock.json
+++ b/packages/europa-core/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-core",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-core",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -35,19 +35,6 @@
 			},
 			"engines": {
 				"node": "^12.20.0 || >=14"
-			}
-		},
-		"node_modules/@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -90,34 +77,6 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -153,34 +112,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/@tsconfig/node10": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node12": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node14": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node16": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -192,13 +123,6 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
-		},
-		"node_modules/@types/node": {
-			"version": "17.0.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-			"integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "5.26.0",
@@ -405,16 +329,6 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
-		"node_modules/acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -454,13 +368,6 @@
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
-		},
-		"node_modules/arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
@@ -604,13 +511,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"node_modules/create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -662,16 +562,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/dir-glob": {
@@ -1837,13 +1727,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2404,50 +2287,6 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/ts-node": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
-			"integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			},
-			"bin": {
-				"ts-node": "dist/bin.js",
-				"ts-node-cwd": "dist/bin-cwd.js",
-				"ts-node-esm": "dist/bin-esm.js",
-				"ts-node-script": "dist/bin-script.js",
-				"ts-node-transpile-only": "dist/bin-transpile.js",
-				"ts-script": "dist/bin-script-deprecated.js"
-			},
-			"peerDependencies": {
-				"@swc/core": ">=1.2.50",
-				"@swc/wasm": ">=1.2.50",
-				"@types/node": "*",
-				"typescript": ">=2.7"
-			},
-			"peerDependenciesMeta": {
-				"@swc/core": {
-					"optional": true
-				},
-				"@swc/wasm": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/tsconfig-paths": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz",
@@ -2576,13 +2415,6 @@
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
-		"node_modules/v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2634,29 +2466,9 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"node_modules/yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6"
-			}
 		}
 	},
 	"dependencies": {
-		"@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			}
-		},
 		"@eslint/eslintrc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -2691,31 +2503,6 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"@jridgewell/resolve-uri": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
-			"dev": true,
-			"peer": true
-		},
-		"@jridgewell/sourcemap-codec": {
-			"version": "1.4.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
-			"dev": true,
-			"peer": true
-		},
-		"@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2742,34 +2529,6 @@
 				"fastq": "^1.6.0"
 			}
 		},
-		"@tsconfig/node10": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node12": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node14": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node16": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-			"dev": true,
-			"peer": true
-		},
 		"@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -2781,13 +2540,6 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
-		},
-		"@types/node": {
-			"version": "17.0.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-			"integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
-			"dev": true,
-			"peer": true
 		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "5.26.0",
@@ -2894,15 +2646,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
-			"requires": {}
-		},
-		"acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"ajv": {
 			"version": "6.12.6",
@@ -2930,13 +2674,6 @@
 			"requires": {
 				"color-convert": "^2.0.1"
 			}
-		},
-		"arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"peer": true
 		},
 		"argparse": {
 			"version": "2.0.1",
@@ -3047,13 +2784,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"peer": true
-		},
 		"cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3089,13 +2819,6 @@
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
 			}
-		},
-		"diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"peer": true
 		},
 		"dir-glob": {
 			"version": "3.0.1",
@@ -3237,8 +2960,7 @@
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
 			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",
@@ -3975,13 +3697,6 @@
 				"yallist": "^4.0.0"
 			}
 		},
-		"make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"peer": true
-		},
 		"merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4357,28 +4072,6 @@
 				"is-number": "^7.0.0"
 			}
 		},
-		"ts-node": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
-			"integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			}
-		},
 		"tsconfig-paths": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz",
@@ -4471,13 +4164,6 @@
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
-		"v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"peer": true
-		},
 		"which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4517,13 +4203,6 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-core/package.json
+++ b/packages/europa-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-core",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Europa core engine for converting HTML into valid Markdown",
   "keywords": [
     "europa",

--- a/packages/europa-dom-cheerio/package-lock.json
+++ b/packages/europa-dom-cheerio/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-dom-cheerio",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-dom-cheerio",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -43,20 +43,7 @@
 				"node": "^12.20.0 || >=14"
 			},
 			"peerDependencies": {
-				"europa-core": "^5.0.1"
-			}
-		},
-		"node_modules/@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			},
-			"engines": {
-				"node": ">=12"
+				"europa-core": "^6.0.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -99,34 +86,6 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -161,34 +120,6 @@
 			"engines": {
 				"node": ">= 8"
 			}
-		},
-		"node_modules/@tsconfig/node10": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node12": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node14": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node16": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.11",
@@ -419,16 +350,6 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
-		"node_modules/acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -468,13 +389,6 @@
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
-		},
-		"node_modules/arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
@@ -660,13 +574,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"node_modules/create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -744,16 +651,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/dir-glob": {
@@ -1309,22 +1206,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/neocotic"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/neocotic"
-				}
-			],
-			"peer": true
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -2020,13 +1901,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2621,50 +2495,6 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/ts-node": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
-			"integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			},
-			"bin": {
-				"ts-node": "dist/bin.js",
-				"ts-node-cwd": "dist/bin-cwd.js",
-				"ts-node-esm": "dist/bin-esm.js",
-				"ts-node-script": "dist/bin-script.js",
-				"ts-node-transpile-only": "dist/bin-transpile.js",
-				"ts-script": "dist/bin-script-deprecated.js"
-			},
-			"peerDependencies": {
-				"@swc/core": ">=1.2.50",
-				"@swc/wasm": ">=1.2.50",
-				"@types/node": "*",
-				"typescript": ">=2.7"
-			},
-			"peerDependenciesMeta": {
-				"@swc/core": {
-					"optional": true
-				},
-				"@swc/wasm": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/tsconfig-paths": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz",
@@ -2798,13 +2628,6 @@
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
-		"node_modules/v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2856,29 +2679,9 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"node_modules/yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6"
-			}
 		}
 	},
 	"dependencies": {
-		"@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			}
-		},
 		"@eslint/eslintrc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -2913,31 +2716,6 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"@jridgewell/resolve-uri": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
-			"dev": true,
-			"peer": true
-		},
-		"@jridgewell/sourcemap-codec": {
-			"version": "1.4.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
-			"dev": true,
-			"peer": true
-		},
-		"@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2963,34 +2741,6 @@
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
 			}
-		},
-		"@tsconfig/node10": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node12": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node14": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node16": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-			"dev": true,
-			"peer": true
 		},
 		"@types/json-schema": {
 			"version": "7.0.11",
@@ -3121,15 +2871,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
-			"requires": {}
-		},
-		"acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"ajv": {
 			"version": "6.12.6",
@@ -3157,13 +2899,6 @@
 			"requires": {
 				"color-convert": "^2.0.1"
 			}
-		},
-		"arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"peer": true
 		},
 		"argparse": {
 			"version": "2.0.1",
@@ -3307,13 +3042,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"peer": true
-		},
 		"cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3366,13 +3094,6 @@
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
 			}
-		},
-		"diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"peer": true
 		},
 		"dir-glob": {
 			"version": "3.0.1",
@@ -3552,8 +3273,7 @@
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
 			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",
@@ -3799,12 +3519,6 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
-		},
-		"europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"peer": true
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
@@ -4312,13 +4026,6 @@
 				"yallist": "^4.0.0"
 			}
 		},
-		"make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"peer": true
-		},
 		"merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4719,28 +4426,6 @@
 				"is-number": "^7.0.0"
 			}
 		},
-		"ts-node": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
-			"integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			}
-		},
 		"tsconfig-paths": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz",
@@ -4840,13 +4525,6 @@
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
-		"v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"peer": true
-		},
 		"which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4886,13 +4564,6 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-dom-cheerio/package.json
+++ b/packages/europa-dom-cheerio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-dom-cheerio",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Europa DOM wrapper using cheerio",
   "keywords": [
     "cheerio",
@@ -37,7 +37,7 @@
     "lodash": "^4.17.21"
   },
   "peerDependencies": {
-    "europa-core": "^5.0.1"
+    "europa-core": "^6.0.0"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.182",
@@ -49,7 +49,7 @@
     "eslint-import-resolver-typescript": "^2.7.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "europa-core": "^5.0.1",
+    "europa-core": "^6.0.0",
     "prettier": "^2.6.2",
     "rimraf": "^3.0.2",
     "tsconfig-paths": "^4.0.0",

--- a/packages/europa-dom-web/package-lock.json
+++ b/packages/europa-dom-web/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-dom-web",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-dom-web",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -37,20 +37,7 @@
 				"node": "^12.20.0 || >=14"
 			},
 			"peerDependencies": {
-				"europa-core": "^5.0.1"
-			}
-		},
-		"node_modules/@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			},
-			"engines": {
-				"node": ">=12"
+				"europa-core": "^6.0.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -93,34 +80,6 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -156,34 +115,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/@tsconfig/node10": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node12": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node14": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node16": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -195,13 +126,6 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
-		},
-		"node_modules/@types/node": {
-			"version": "17.0.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-			"integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "5.26.0",
@@ -408,16 +332,6 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
-		"node_modules/acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -457,13 +371,6 @@
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
-		},
-		"node_modules/arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
@@ -607,13 +514,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"node_modules/create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -665,16 +565,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/dir-glob": {
@@ -1168,22 +1058,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/neocotic"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/neocotic"
-				}
-			],
-			"peer": true
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -1856,13 +1730,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2423,50 +2290,6 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/ts-node": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
-			"integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			},
-			"bin": {
-				"ts-node": "dist/bin.js",
-				"ts-node-cwd": "dist/bin-cwd.js",
-				"ts-node-esm": "dist/bin-esm.js",
-				"ts-node-script": "dist/bin-script.js",
-				"ts-node-transpile-only": "dist/bin-transpile.js",
-				"ts-script": "dist/bin-script-deprecated.js"
-			},
-			"peerDependencies": {
-				"@swc/core": ">=1.2.50",
-				"@swc/wasm": ">=1.2.50",
-				"@types/node": "*",
-				"typescript": ">=2.7"
-			},
-			"peerDependenciesMeta": {
-				"@swc/core": {
-					"optional": true
-				},
-				"@swc/wasm": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/tsconfig-paths": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz",
@@ -2595,13 +2418,6 @@
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
-		"node_modules/v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2653,29 +2469,9 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"node_modules/yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6"
-			}
 		}
 	},
 	"dependencies": {
-		"@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			}
-		},
 		"@eslint/eslintrc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -2710,31 +2506,6 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"@jridgewell/resolve-uri": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
-			"dev": true,
-			"peer": true
-		},
-		"@jridgewell/sourcemap-codec": {
-			"version": "1.4.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
-			"dev": true,
-			"peer": true
-		},
-		"@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2761,34 +2532,6 @@
 				"fastq": "^1.6.0"
 			}
 		},
-		"@tsconfig/node10": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node12": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node14": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node16": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-			"dev": true,
-			"peer": true
-		},
 		"@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -2800,13 +2543,6 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
-		},
-		"@types/node": {
-			"version": "17.0.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-			"integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
-			"dev": true,
-			"peer": true
 		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "5.26.0",
@@ -2913,15 +2649,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
-			"requires": {}
-		},
-		"acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"ajv": {
 			"version": "6.12.6",
@@ -2949,13 +2677,6 @@
 			"requires": {
 				"color-convert": "^2.0.1"
 			}
-		},
-		"arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"peer": true
 		},
 		"argparse": {
 			"version": "2.0.1",
@@ -3066,13 +2787,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"peer": true
-		},
 		"cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3108,13 +2822,6 @@
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
 			}
-		},
-		"diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"peer": true
 		},
 		"dir-glob": {
 			"version": "3.0.1",
@@ -3256,8 +2963,7 @@
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
 			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",
@@ -3503,12 +3209,6 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
-		},
-		"europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"peer": true
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
@@ -4000,13 +3700,6 @@
 				"yallist": "^4.0.0"
 			}
 		},
-		"make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"peer": true
-		},
 		"merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4382,28 +4075,6 @@
 				"is-number": "^7.0.0"
 			}
 		},
-		"ts-node": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
-			"integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			}
-		},
 		"tsconfig-paths": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz",
@@ -4496,13 +4167,6 @@
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
-		"v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"peer": true
-		},
 		"which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4542,13 +4206,6 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-dom-web/package.json
+++ b/packages/europa-dom-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-dom-web",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Europa DOM wrapper for a web browser",
   "keywords": [
     "browser",
@@ -34,7 +34,7 @@
     "directory": "packages/europa-dom-web"
   },
   "peerDependencies": {
-    "europa-core": "^5.0.1"
+    "europa-core": "^6.0.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.22.0",
@@ -44,7 +44,7 @@
     "eslint-import-resolver-typescript": "^2.7.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "europa-core": "^5.0.1",
+    "europa-core": "^6.0.0",
     "prettier": "^2.6.2",
     "rimraf": "^3.0.2",
     "tsconfig-paths": "^4.0.0",

--- a/packages/europa-environment-node/package-lock.json
+++ b/packages/europa-environment-node/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-environment-node",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-environment-node",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -38,20 +38,7 @@
 				"node": "^12.20.0 || >=14"
 			},
 			"peerDependencies": {
-				"europa-core": "^5.0.1"
-			}
-		},
-		"node_modules/@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			},
-			"engines": {
-				"node": ">=12"
+				"europa-core": "^6.0.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -94,34 +81,6 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -157,34 +116,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/@tsconfig/node10": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node12": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node14": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node16": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -202,13 +133,6 @@
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
 			"integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
 			"dev": true
-		},
-		"node_modules/@types/node": {
-			"version": "17.0.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-			"integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "5.26.0",
@@ -415,16 +339,6 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
-		"node_modules/acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -464,13 +378,6 @@
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
-		},
-		"node_modules/arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
@@ -614,13 +521,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"node_modules/create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -672,16 +572,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/dir-glob": {
@@ -1175,22 +1065,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/neocotic"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/neocotic"
-				}
-			],
-			"peer": true
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -1863,13 +1737,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2430,50 +2297,6 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/ts-node": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
-			"integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			},
-			"bin": {
-				"ts-node": "dist/bin.js",
-				"ts-node-cwd": "dist/bin-cwd.js",
-				"ts-node-esm": "dist/bin-esm.js",
-				"ts-node-script": "dist/bin-script.js",
-				"ts-node-transpile-only": "dist/bin-transpile.js",
-				"ts-script": "dist/bin-script-deprecated.js"
-			},
-			"peerDependencies": {
-				"@swc/core": ">=1.2.50",
-				"@swc/wasm": ">=1.2.50",
-				"@types/node": "*",
-				"typescript": ">=2.7"
-			},
-			"peerDependenciesMeta": {
-				"@swc/core": {
-					"optional": true
-				},
-				"@swc/wasm": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/tsconfig-paths": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz",
@@ -2602,13 +2425,6 @@
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
-		"node_modules/v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2660,29 +2476,9 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"node_modules/yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6"
-			}
 		}
 	},
 	"dependencies": {
-		"@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			}
-		},
 		"@eslint/eslintrc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -2717,31 +2513,6 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"@jridgewell/resolve-uri": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
-			"dev": true,
-			"peer": true
-		},
-		"@jridgewell/sourcemap-codec": {
-			"version": "1.4.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
-			"dev": true,
-			"peer": true
-		},
-		"@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2768,34 +2539,6 @@
 				"fastq": "^1.6.0"
 			}
 		},
-		"@tsconfig/node10": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node12": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node14": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node16": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-			"dev": true,
-			"peer": true
-		},
 		"@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -2813,13 +2556,6 @@
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
 			"integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
 			"dev": true
-		},
-		"@types/node": {
-			"version": "17.0.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-			"integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
-			"dev": true,
-			"peer": true
 		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "5.26.0",
@@ -2926,15 +2662,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
-			"requires": {}
-		},
-		"acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"ajv": {
 			"version": "6.12.6",
@@ -2962,13 +2690,6 @@
 			"requires": {
 				"color-convert": "^2.0.1"
 			}
-		},
-		"arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"peer": true
 		},
 		"argparse": {
 			"version": "2.0.1",
@@ -3079,13 +2800,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"peer": true
-		},
 		"cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3121,13 +2835,6 @@
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
 			}
-		},
-		"diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"peer": true
 		},
 		"dir-glob": {
 			"version": "3.0.1",
@@ -3269,8 +2976,7 @@
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
 			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",
@@ -3516,12 +3222,6 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
-		},
-		"europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"peer": true
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
@@ -4013,13 +3713,6 @@
 				"yallist": "^4.0.0"
 			}
 		},
-		"make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"peer": true
-		},
 		"merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4395,28 +4088,6 @@
 				"is-number": "^7.0.0"
 			}
 		},
-		"ts-node": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
-			"integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			}
-		},
 		"tsconfig-paths": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz",
@@ -4509,13 +4180,6 @@
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
-		"v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"peer": true
-		},
 		"which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4555,13 +4219,6 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-environment-node/package.json
+++ b/packages/europa-environment-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-environment-node",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Europa environment for Node.js",
   "keywords": [
     "node",
@@ -33,10 +33,10 @@
     "directory": "packages/europa-environment-node"
   },
   "dependencies": {
-    "europa-dom-cheerio": "^5.0.1"
+    "europa-dom-cheerio": "^6.0.0"
   },
   "peerDependencies": {
-    "europa-core": "^5.0.1"
+    "europa-core": "^6.0.0"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.182",
@@ -47,7 +47,7 @@
     "eslint-import-resolver-typescript": "^2.7.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "europa-core": "^5.0.1",
+    "europa-core": "^6.0.0",
     "prettier": "^2.6.2",
     "rimraf": "^3.0.2",
     "tsconfig-paths": "^4.0.0",

--- a/packages/europa-environment-web/package-lock.json
+++ b/packages/europa-environment-web/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-environment-web",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-environment-web",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -37,20 +37,7 @@
 				"node": "^12.20.0 || >=14"
 			},
 			"peerDependencies": {
-				"europa-core": "^5.0.1"
-			}
-		},
-		"node_modules/@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			},
-			"engines": {
-				"node": ">=12"
+				"europa-core": "^6.0.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -93,34 +80,6 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -156,34 +115,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/@tsconfig/node10": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node12": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node14": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node16": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -195,13 +126,6 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
-		},
-		"node_modules/@types/node": {
-			"version": "17.0.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-			"integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "5.26.0",
@@ -408,16 +332,6 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
-		"node_modules/acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -457,13 +371,6 @@
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
-		},
-		"node_modules/arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
@@ -607,13 +514,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"node_modules/create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -665,16 +565,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/dir-glob": {
@@ -1168,22 +1058,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/neocotic"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/neocotic"
-				}
-			],
-			"peer": true
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -1856,13 +1730,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2423,50 +2290,6 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/ts-node": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
-			"integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			},
-			"bin": {
-				"ts-node": "dist/bin.js",
-				"ts-node-cwd": "dist/bin-cwd.js",
-				"ts-node-esm": "dist/bin-esm.js",
-				"ts-node-script": "dist/bin-script.js",
-				"ts-node-transpile-only": "dist/bin-transpile.js",
-				"ts-script": "dist/bin-script-deprecated.js"
-			},
-			"peerDependencies": {
-				"@swc/core": ">=1.2.50",
-				"@swc/wasm": ">=1.2.50",
-				"@types/node": "*",
-				"typescript": ">=2.7"
-			},
-			"peerDependenciesMeta": {
-				"@swc/core": {
-					"optional": true
-				},
-				"@swc/wasm": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/tsconfig-paths": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz",
@@ -2595,13 +2418,6 @@
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
-		"node_modules/v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2653,29 +2469,9 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"node_modules/yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6"
-			}
 		}
 	},
 	"dependencies": {
-		"@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			}
-		},
 		"@eslint/eslintrc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -2710,31 +2506,6 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"@jridgewell/resolve-uri": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
-			"dev": true,
-			"peer": true
-		},
-		"@jridgewell/sourcemap-codec": {
-			"version": "1.4.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
-			"dev": true,
-			"peer": true
-		},
-		"@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2761,34 +2532,6 @@
 				"fastq": "^1.6.0"
 			}
 		},
-		"@tsconfig/node10": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node12": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node14": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node16": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-			"dev": true,
-			"peer": true
-		},
 		"@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -2800,13 +2543,6 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
-		},
-		"@types/node": {
-			"version": "17.0.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-			"integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
-			"dev": true,
-			"peer": true
 		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "5.26.0",
@@ -2913,15 +2649,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
-			"requires": {}
-		},
-		"acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"ajv": {
 			"version": "6.12.6",
@@ -2949,13 +2677,6 @@
 			"requires": {
 				"color-convert": "^2.0.1"
 			}
-		},
-		"arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"peer": true
 		},
 		"argparse": {
 			"version": "2.0.1",
@@ -3066,13 +2787,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"peer": true
-		},
 		"cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3108,13 +2822,6 @@
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
 			}
-		},
-		"diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"peer": true
 		},
 		"dir-glob": {
 			"version": "3.0.1",
@@ -3256,8 +2963,7 @@
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
 			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",
@@ -3503,12 +3209,6 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
-		},
-		"europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"peer": true
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
@@ -4000,13 +3700,6 @@
 				"yallist": "^4.0.0"
 			}
 		},
-		"make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"peer": true
-		},
 		"merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4382,28 +4075,6 @@
 				"is-number": "^7.0.0"
 			}
 		},
-		"ts-node": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
-			"integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			}
-		},
 		"tsconfig-paths": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz",
@@ -4496,13 +4167,6 @@
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
-		"v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"peer": true
-		},
 		"which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4542,13 +4206,6 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-environment-web/package.json
+++ b/packages/europa-environment-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-environment-web",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Europa environment for a web browser",
   "keywords": [
     "browser",
@@ -34,10 +34,10 @@
     "directory": "packages/europa-environment-web"
   },
   "dependencies": {
-    "europa-dom-web": "^5.0.1"
+    "europa-dom-web": "^6.0.0"
   },
   "peerDependencies": {
-    "europa-core": "^5.0.1"
+    "europa-core": "^6.0.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.22.0",
@@ -47,7 +47,7 @@
     "eslint-import-resolver-typescript": "^2.7.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "europa-core": "^5.0.1",
+    "europa-core": "^6.0.0",
     "prettier": "^2.6.2",
     "rimraf": "^3.0.2",
     "tsconfig-paths": "^4.0.0",

--- a/packages/europa-environment-worker/package-lock.json
+++ b/packages/europa-environment-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-environment-worker",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-environment-worker",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -37,20 +37,7 @@
 				"node": "^12.20.0 || >=14"
 			},
 			"peerDependencies": {
-				"europa-core": "^5.0.1"
-			}
-		},
-		"node_modules/@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			},
-			"engines": {
-				"node": ">=12"
+				"europa-core": "^6.0.0"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -93,34 +80,6 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -156,34 +115,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/@tsconfig/node10": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node12": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node14": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node16": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -195,13 +126,6 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
-		},
-		"node_modules/@types/node": {
-			"version": "17.0.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-			"integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "5.26.0",
@@ -408,16 +332,6 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
-		"node_modules/acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -457,13 +371,6 @@
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
-		},
-		"node_modules/arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
@@ -607,13 +514,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"node_modules/create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -665,16 +565,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/dir-glob": {
@@ -1168,22 +1058,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/neocotic"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/neocotic"
-				}
-			],
-			"peer": true
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -1856,13 +1730,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2423,50 +2290,6 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/ts-node": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
-			"integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			},
-			"bin": {
-				"ts-node": "dist/bin.js",
-				"ts-node-cwd": "dist/bin-cwd.js",
-				"ts-node-esm": "dist/bin-esm.js",
-				"ts-node-script": "dist/bin-script.js",
-				"ts-node-transpile-only": "dist/bin-transpile.js",
-				"ts-script": "dist/bin-script-deprecated.js"
-			},
-			"peerDependencies": {
-				"@swc/core": ">=1.2.50",
-				"@swc/wasm": ">=1.2.50",
-				"@types/node": "*",
-				"typescript": ">=2.7"
-			},
-			"peerDependenciesMeta": {
-				"@swc/core": {
-					"optional": true
-				},
-				"@swc/wasm": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/tsconfig-paths": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz",
@@ -2595,13 +2418,6 @@
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
-		"node_modules/v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2653,29 +2469,9 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"node_modules/yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6"
-			}
 		}
 	},
 	"dependencies": {
-		"@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			}
-		},
 		"@eslint/eslintrc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -2710,31 +2506,6 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"@jridgewell/resolve-uri": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
-			"dev": true,
-			"peer": true
-		},
-		"@jridgewell/sourcemap-codec": {
-			"version": "1.4.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
-			"dev": true,
-			"peer": true
-		},
-		"@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2761,34 +2532,6 @@
 				"fastq": "^1.6.0"
 			}
 		},
-		"@tsconfig/node10": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node12": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node14": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node16": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-			"dev": true,
-			"peer": true
-		},
 		"@types/json-schema": {
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -2800,13 +2543,6 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
-		},
-		"@types/node": {
-			"version": "17.0.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-			"integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
-			"dev": true,
-			"peer": true
 		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "5.26.0",
@@ -2913,15 +2649,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
-			"requires": {}
-		},
-		"acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"ajv": {
 			"version": "6.12.6",
@@ -2949,13 +2677,6 @@
 			"requires": {
 				"color-convert": "^2.0.1"
 			}
-		},
-		"arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"peer": true
 		},
 		"argparse": {
 			"version": "2.0.1",
@@ -3066,13 +2787,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"peer": true
-		},
 		"cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3108,13 +2822,6 @@
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
 			}
-		},
-		"diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"peer": true
 		},
 		"dir-glob": {
 			"version": "3.0.1",
@@ -3256,8 +2963,7 @@
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
 			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",
@@ -3503,12 +3209,6 @@
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
-		},
-		"europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"peer": true
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
@@ -4000,13 +3700,6 @@
 				"yallist": "^4.0.0"
 			}
 		},
-		"make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"peer": true
-		},
 		"merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4382,28 +4075,6 @@
 				"is-number": "^7.0.0"
 			}
 		},
-		"ts-node": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
-			"integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			}
-		},
 		"tsconfig-paths": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz",
@@ -4496,13 +4167,6 @@
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
-		"v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"peer": true
-		},
 		"which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4542,13 +4206,6 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-environment-worker/package.json
+++ b/packages/europa-environment-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-environment-worker",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Europa environment for a worker",
   "keywords": [
     "worker",
@@ -33,10 +33,10 @@
     "directory": "packages/europa-environment-worker"
   },
   "dependencies": {
-    "europa-dom-cheerio": "^5.0.1"
+    "europa-dom-cheerio": "^6.0.0"
   },
   "peerDependencies": {
-    "europa-core": "^5.0.1"
+    "europa-core": "^6.0.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.22.0",
@@ -46,7 +46,7 @@
     "eslint-import-resolver-typescript": "^2.7.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "europa-core": "^5.0.1",
+    "europa-core": "^6.0.0",
     "prettier": "^2.6.2",
     "rimraf": "^3.0.2",
     "tsconfig-paths": "^4.0.0",

--- a/packages/europa-plugin-bold/package-lock.json
+++ b/packages/europa-plugin-bold/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-plugin-bold",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-plugin-bold",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -25,7 +25,7 @@
 				"node": "^12.20.0 || >=14"
 			},
 			"peerDependencies": {
-				"europa-core": "^5.0.1"
+				"europa-core": "^6.0.0"
 			}
 		},
 		"node_modules/@types/jasmine": {
@@ -33,22 +33,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"node_modules/europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/neocotic"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/neocotic"
-				}
-			],
-			"peer": true
 		}
 	},
 	"dependencies": {
@@ -57,12 +41,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-plugin-bold/package.json
+++ b/packages/europa-plugin-bold/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-plugin-bold",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Europa plugin to convert HTML tags to Markdown bold text",
   "keywords": [
     "bold",
@@ -34,14 +34,14 @@
     "directory": "packages/europa-plugin-bold"
   },
   "peerDependencies": {
-    "europa-core": "^5.0.1"
+    "europa-core": "^6.0.0"
   },
   "devDependencies": {
     "@types/jasmine": "^4.0.3",
-    "europa-build": "^5.0.1",
-    "europa-core": "^5.0.1",
-    "europa-environment-node": "^5.0.1",
-    "europa-test-jasmine-reporter": "^5.0.1"
+    "europa-build": "^6.0.0",
+    "europa-core": "^6.0.0",
+    "europa-environment-node": "^6.0.0",
+    "europa-test-jasmine-reporter": "^6.0.0"
   },
   "scripts": {
     "build": "europa-build run-script build",

--- a/packages/europa-plugin-code/package-lock.json
+++ b/packages/europa-plugin-code/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-plugin-code",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-plugin-code",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -25,7 +25,7 @@
 				"node": "^12.20.0 || >=14"
 			},
 			"peerDependencies": {
-				"europa-core": "^5.0.1"
+				"europa-core": "^6.0.0"
 			}
 		},
 		"node_modules/@types/jasmine": {
@@ -33,22 +33,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"node_modules/europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/neocotic"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/neocotic"
-				}
-			],
-			"peer": true
 		}
 	},
 	"dependencies": {
@@ -57,12 +41,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-plugin-code/package.json
+++ b/packages/europa-plugin-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-plugin-code",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Europa plugin to convert HTML tags to Markdown inline code",
   "keywords": [
     "code",
@@ -33,14 +33,14 @@
     "directory": "packages/europa-plugin-code"
   },
   "peerDependencies": {
-    "europa-core": "^5.0.1"
+    "europa-core": "^6.0.0"
   },
   "devDependencies": {
     "@types/jasmine": "^4.0.3",
-    "europa-build": "^5.0.1",
-    "europa-core": "^5.0.1",
-    "europa-environment-node": "^5.0.1",
-    "europa-test-jasmine-reporter": "^5.0.1"
+    "europa-build": "^6.0.0",
+    "europa-core": "^6.0.0",
+    "europa-environment-node": "^6.0.0",
+    "europa-test-jasmine-reporter": "^6.0.0"
   },
   "scripts": {
     "build": "europa-build run-script build",

--- a/packages/europa-plugin-description/package-lock.json
+++ b/packages/europa-plugin-description/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-plugin-description",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-plugin-description",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -25,7 +25,7 @@
 				"node": "^12.20.0 || >=14"
 			},
 			"peerDependencies": {
-				"europa-core": "^5.0.1"
+				"europa-core": "^6.0.0"
 			}
 		},
 		"node_modules/@types/jasmine": {
@@ -33,22 +33,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"node_modules/europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/neocotic"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/neocotic"
-				}
-			],
-			"peer": true
 		}
 	},
 	"dependencies": {
@@ -57,12 +41,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-plugin-description/package.json
+++ b/packages/europa-plugin-description/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-plugin-description",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Europa plugin to convert HTML description list tags to Markdown",
   "keywords": [
     "description",
@@ -34,14 +34,14 @@
     "directory": "packages/europa-plugin-description"
   },
   "peerDependencies": {
-    "europa-core": "^5.0.1"
+    "europa-core": "^6.0.0"
   },
   "devDependencies": {
     "@types/jasmine": "^4.0.3",
-    "europa-build": "^5.0.1",
-    "europa-core": "^5.0.1",
-    "europa-environment-node": "^5.0.1",
-    "europa-test-jasmine-reporter": "^5.0.1"
+    "europa-build": "^6.0.0",
+    "europa-core": "^6.0.0",
+    "europa-environment-node": "^6.0.0",
+    "europa-test-jasmine-reporter": "^6.0.0"
   },
   "scripts": {
     "build": "europa-build run-script build",

--- a/packages/europa-plugin-details/package-lock.json
+++ b/packages/europa-plugin-details/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-plugin-details",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-plugin-details",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -25,7 +25,7 @@
 				"node": "^12.20.0 || >=14"
 			},
 			"peerDependencies": {
-				"europa-core": "^5.0.1"
+				"europa-core": "^6.0.0"
 			}
 		},
 		"node_modules/@types/jasmine": {
@@ -33,22 +33,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"node_modules/europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/neocotic"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/neocotic"
-				}
-			],
-			"peer": true
 		}
 	},
 	"dependencies": {
@@ -57,12 +41,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-plugin-details/package.json
+++ b/packages/europa-plugin-details/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-plugin-details",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Europa plugin to convert HTML details tags to Markdown",
   "keywords": [
     "details",
@@ -34,14 +34,14 @@
     "directory": "packages/europa-plugin-details"
   },
   "peerDependencies": {
-    "europa-core": "^5.0.1"
+    "europa-core": "^6.0.0"
   },
   "devDependencies": {
     "@types/jasmine": "^4.0.3",
-    "europa-build": "^5.0.1",
-    "europa-core": "^5.0.1",
-    "europa-environment-node": "^5.0.1",
-    "europa-test-jasmine-reporter": "^5.0.1"
+    "europa-build": "^6.0.0",
+    "europa-core": "^6.0.0",
+    "europa-environment-node": "^6.0.0",
+    "europa-test-jasmine-reporter": "^6.0.0"
   },
   "scripts": {
     "build": "europa-build run-script build",

--- a/packages/europa-plugin-header/package-lock.json
+++ b/packages/europa-plugin-header/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-plugin-header",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-plugin-header",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -25,7 +25,7 @@
 				"node": "^12.20.0 || >=14"
 			},
 			"peerDependencies": {
-				"europa-core": "^5.0.1"
+				"europa-core": "^6.0.0"
 			}
 		},
 		"node_modules/@types/jasmine": {
@@ -33,22 +33,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"node_modules/europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/neocotic"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/neocotic"
-				}
-			],
-			"peer": true
 		}
 	},
 	"dependencies": {
@@ -57,12 +41,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-plugin-header/package.json
+++ b/packages/europa-plugin-header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-plugin-header",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Europa plugin to convert HTML tags to Markdown headers",
   "keywords": [
     "header",
@@ -34,14 +34,14 @@
     "directory": "packages/europa-plugin-header"
   },
   "peerDependencies": {
-    "europa-core": "^5.0.1"
+    "europa-core": "^6.0.0"
   },
   "devDependencies": {
     "@types/jasmine": "^4.0.3",
-    "europa-build": "^5.0.1",
-    "europa-core": "^5.0.1",
-    "europa-environment-node": "^5.0.1",
-    "europa-test-jasmine-reporter": "^5.0.1"
+    "europa-build": "^6.0.0",
+    "europa-core": "^6.0.0",
+    "europa-environment-node": "^6.0.0",
+    "europa-test-jasmine-reporter": "^6.0.0"
   },
   "scripts": {
     "build": "europa-build run-script build",

--- a/packages/europa-plugin-horizontal-rule/package-lock.json
+++ b/packages/europa-plugin-horizontal-rule/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-plugin-horizontal-rule",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-plugin-horizontal-rule",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -25,7 +25,7 @@
 				"node": "^12.20.0 || >=14"
 			},
 			"peerDependencies": {
-				"europa-core": "^5.0.1"
+				"europa-core": "^6.0.0"
 			}
 		},
 		"node_modules/@types/jasmine": {
@@ -33,22 +33,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"node_modules/europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/neocotic"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/neocotic"
-				}
-			],
-			"peer": true
 		}
 	},
 	"dependencies": {
@@ -57,12 +41,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-plugin-horizontal-rule/package.json
+++ b/packages/europa-plugin-horizontal-rule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-plugin-horizontal-rule",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Europa plugin to convert HTML tags to Markdown horizontal rules",
   "keywords": [
     "horizontal",
@@ -34,14 +34,14 @@
     "directory": "packages/europa-plugin-horizontal-rule"
   },
   "peerDependencies": {
-    "europa-core": "^5.0.1"
+    "europa-core": "^6.0.0"
   },
   "devDependencies": {
     "@types/jasmine": "^4.0.3",
-    "europa-build": "^5.0.1",
-    "europa-core": "^5.0.1",
-    "europa-environment-node": "^5.0.1",
-    "europa-test-jasmine-reporter": "^5.0.1"
+    "europa-build": "^6.0.0",
+    "europa-core": "^6.0.0",
+    "europa-environment-node": "^6.0.0",
+    "europa-test-jasmine-reporter": "^6.0.0"
   },
   "scripts": {
     "build": "europa-build run-script build",

--- a/packages/europa-plugin-image/package-lock.json
+++ b/packages/europa-plugin-image/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-plugin-image",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-plugin-image",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -25,7 +25,7 @@
 				"node": "^12.20.0 || >=14"
 			},
 			"peerDependencies": {
-				"europa-core": "^5.0.1"
+				"europa-core": "^6.0.0"
 			}
 		},
 		"node_modules/@types/jasmine": {
@@ -33,22 +33,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"node_modules/europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/neocotic"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/neocotic"
-				}
-			],
-			"peer": true
 		}
 	},
 	"dependencies": {
@@ -57,12 +41,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-plugin-image/package.json
+++ b/packages/europa-plugin-image/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-plugin-image",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Europa plugin to convert HTML tags to Markdown images",
   "keywords": [
     "image",
@@ -33,14 +33,14 @@
     "directory": "packages/europa-plugin-image"
   },
   "peerDependencies": {
-    "europa-core": "^5.0.1"
+    "europa-core": "^6.0.0"
   },
   "devDependencies": {
     "@types/jasmine": "^4.0.3",
-    "europa-build": "^5.0.1",
-    "europa-core": "^5.0.1",
-    "europa-environment-node": "^5.0.1",
-    "europa-test-jasmine-reporter": "^5.0.1"
+    "europa-build": "^6.0.0",
+    "europa-core": "^6.0.0",
+    "europa-environment-node": "^6.0.0",
+    "europa-test-jasmine-reporter": "^6.0.0"
   },
   "scripts": {
     "build": "europa-build run-script build",

--- a/packages/europa-plugin-italic/package-lock.json
+++ b/packages/europa-plugin-italic/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-plugin-italic",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-plugin-italic",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -25,7 +25,7 @@
 				"node": "^12.20.0 || >=14"
 			},
 			"peerDependencies": {
-				"europa-core": "^5.0.1"
+				"europa-core": "^6.0.0"
 			}
 		},
 		"node_modules/@types/jasmine": {
@@ -33,22 +33,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"node_modules/europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/neocotic"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/neocotic"
-				}
-			],
-			"peer": true
 		}
 	},
 	"dependencies": {
@@ -57,12 +41,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-plugin-italic/package.json
+++ b/packages/europa-plugin-italic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-plugin-italic",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Europa plugin to convert HTML tags to Markdown italic text",
   "keywords": [
     "italic",
@@ -33,14 +33,14 @@
     "directory": "packages/europa-plugin-italic"
   },
   "peerDependencies": {
-    "europa-core": "^5.0.1"
+    "europa-core": "^6.0.0"
   },
   "devDependencies": {
     "@types/jasmine": "^4.0.3",
-    "europa-build": "^5.0.1",
-    "europa-core": "^5.0.1",
-    "europa-environment-node": "^5.0.1",
-    "europa-test-jasmine-reporter": "^5.0.1"
+    "europa-build": "^6.0.0",
+    "europa-core": "^6.0.0",
+    "europa-environment-node": "^6.0.0",
+    "europa-test-jasmine-reporter": "^6.0.0"
   },
   "scripts": {
     "build": "europa-build run-script build",

--- a/packages/europa-plugin-line-break/package-lock.json
+++ b/packages/europa-plugin-line-break/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-plugin-line-break",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-plugin-line-break",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -25,7 +25,7 @@
 				"node": "^12.20.0 || >=14"
 			},
 			"peerDependencies": {
-				"europa-core": "^5.0.1"
+				"europa-core": "^6.0.0"
 			}
 		},
 		"node_modules/@types/jasmine": {
@@ -33,22 +33,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"node_modules/europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/neocotic"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/neocotic"
-				}
-			],
-			"peer": true
 		}
 	},
 	"dependencies": {
@@ -57,12 +41,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-plugin-line-break/package.json
+++ b/packages/europa-plugin-line-break/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-plugin-line-break",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Europa plugin to convert HTML tags to Markdown line breaks",
   "keywords": [
     "line",
@@ -34,14 +34,14 @@
     "directory": "packages/europa-plugin-line-break"
   },
   "peerDependencies": {
-    "europa-core": "^5.0.1"
+    "europa-core": "^6.0.0"
   },
   "devDependencies": {
     "@types/jasmine": "^4.0.3",
-    "europa-build": "^5.0.1",
-    "europa-core": "^5.0.1",
-    "europa-environment-node": "^5.0.1",
-    "europa-test-jasmine-reporter": "^5.0.1"
+    "europa-build": "^6.0.0",
+    "europa-core": "^6.0.0",
+    "europa-environment-node": "^6.0.0",
+    "europa-test-jasmine-reporter": "^6.0.0"
   },
   "scripts": {
     "build": "europa-build run-script build",

--- a/packages/europa-plugin-link/package-lock.json
+++ b/packages/europa-plugin-link/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-plugin-link",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-plugin-link",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -25,7 +25,7 @@
 				"node": "^12.20.0 || >=14"
 			},
 			"peerDependencies": {
-				"europa-core": "^5.0.1"
+				"europa-core": "^6.0.0"
 			}
 		},
 		"node_modules/@types/jasmine": {
@@ -33,22 +33,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"node_modules/europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/neocotic"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/neocotic"
-				}
-			],
-			"peer": true
 		}
 	},
 	"dependencies": {
@@ -57,12 +41,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-plugin-link/package.json
+++ b/packages/europa-plugin-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-plugin-link",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Europa plugin to convert HTML tags to Markdown links",
   "keywords": [
     "anchor",
@@ -35,14 +35,14 @@
     "directory": "packages/europa-plugin-link"
   },
   "peerDependencies": {
-    "europa-core": "^5.0.1"
+    "europa-core": "^6.0.0"
   },
   "devDependencies": {
     "@types/jasmine": "^4.0.3",
-    "europa-build": "^5.0.1",
-    "europa-core": "^5.0.1",
-    "europa-environment-node": "^5.0.1",
-    "europa-test-jasmine-reporter": "^5.0.1"
+    "europa-build": "^6.0.0",
+    "europa-core": "^6.0.0",
+    "europa-environment-node": "^6.0.0",
+    "europa-test-jasmine-reporter": "^6.0.0"
   },
   "scripts": {
     "build": "europa-build run-script build",

--- a/packages/europa-plugin-list/package-lock.json
+++ b/packages/europa-plugin-list/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-plugin-list",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-plugin-list",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -25,7 +25,7 @@
 				"node": "^12.20.0 || >=14"
 			},
 			"peerDependencies": {
-				"europa-core": "^5.0.1"
+				"europa-core": "^6.0.0"
 			}
 		},
 		"node_modules/@types/jasmine": {
@@ -33,22 +33,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"node_modules/europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/neocotic"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/neocotic"
-				}
-			],
-			"peer": true
 		}
 	},
 	"dependencies": {
@@ -57,12 +41,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-plugin-list/package.json
+++ b/packages/europa-plugin-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-plugin-list",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Europa plugin to convert HTML tags to Markdown lists",
   "keywords": [
     "list",
@@ -35,14 +35,14 @@
     "directory": "packages/europa-plugin-list"
   },
   "peerDependencies": {
-    "europa-core": "^5.0.1"
+    "europa-core": "^6.0.0"
   },
   "devDependencies": {
     "@types/jasmine": "^4.0.3",
-    "europa-build": "^5.0.1",
-    "europa-core": "^5.0.1",
-    "europa-environment-node": "^5.0.1",
-    "europa-test-jasmine-reporter": "^5.0.1"
+    "europa-build": "^6.0.0",
+    "europa-core": "^6.0.0",
+    "europa-environment-node": "^6.0.0",
+    "europa-test-jasmine-reporter": "^6.0.0"
   },
   "scripts": {
     "build": "europa-build run-script build",

--- a/packages/europa-plugin-paragraph/package-lock.json
+++ b/packages/europa-plugin-paragraph/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-plugin-paragraph",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-plugin-paragraph",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -25,7 +25,7 @@
 				"node": "^12.20.0 || >=14"
 			},
 			"peerDependencies": {
-				"europa-core": "^5.0.1"
+				"europa-core": "^6.0.0"
 			}
 		},
 		"node_modules/@types/jasmine": {
@@ -33,22 +33,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"node_modules/europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/neocotic"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/neocotic"
-				}
-			],
-			"peer": true
 		}
 	},
 	"dependencies": {
@@ -57,12 +41,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-plugin-paragraph/package.json
+++ b/packages/europa-plugin-paragraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-plugin-paragraph",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Europa plugin to convert HTML tags to Markdown paragraphs",
   "keywords": [
     "paragraph",
@@ -33,14 +33,14 @@
     "directory": "packages/europa-plugin-paragraph"
   },
   "peerDependencies": {
-    "europa-core": "^5.0.1"
+    "europa-core": "^6.0.0"
   },
   "devDependencies": {
     "@types/jasmine": "^4.0.3",
-    "europa-build": "^5.0.1",
-    "europa-core": "^5.0.1",
-    "europa-environment-node": "^5.0.1",
-    "europa-test-jasmine-reporter": "^5.0.1"
+    "europa-build": "^6.0.0",
+    "europa-core": "^6.0.0",
+    "europa-environment-node": "^6.0.0",
+    "europa-test-jasmine-reporter": "^6.0.0"
   },
   "scripts": {
     "build": "europa-build run-script build",

--- a/packages/europa-plugin-preformatted/package-lock.json
+++ b/packages/europa-plugin-preformatted/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-plugin-preformatted",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-plugin-preformatted",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -25,7 +25,7 @@
 				"node": "^12.20.0 || >=14"
 			},
 			"peerDependencies": {
-				"europa-core": "^5.0.1"
+				"europa-core": "^6.0.0"
 			}
 		},
 		"node_modules/@types/jasmine": {
@@ -33,22 +33,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"node_modules/europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/neocotic"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/neocotic"
-				}
-			],
-			"peer": true
 		}
 	},
 	"dependencies": {
@@ -57,12 +41,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-plugin-preformatted/package.json
+++ b/packages/europa-plugin-preformatted/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-plugin-preformatted",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Europa plugin to convert HTML tags to Markdown preformatted blocks",
   "keywords": [
     "code",
@@ -34,14 +34,14 @@
     "directory": "packages/europa-plugin-preformatted"
   },
   "peerDependencies": {
-    "europa-core": "^5.0.1"
+    "europa-core": "^6.0.0"
   },
   "devDependencies": {
     "@types/jasmine": "^4.0.3",
-    "europa-build": "^5.0.1",
-    "europa-core": "^5.0.1",
-    "europa-environment-node": "^5.0.1",
-    "europa-test-jasmine-reporter": "^5.0.1"
+    "europa-build": "^6.0.0",
+    "europa-core": "^6.0.0",
+    "europa-environment-node": "^6.0.0",
+    "europa-test-jasmine-reporter": "^6.0.0"
   },
   "scripts": {
     "build": "europa-build run-script build",

--- a/packages/europa-plugin-quote/package-lock.json
+++ b/packages/europa-plugin-quote/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-plugin-quote",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-plugin-quote",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -25,7 +25,7 @@
 				"node": "^12.20.0 || >=14"
 			},
 			"peerDependencies": {
-				"europa-core": "^5.0.1"
+				"europa-core": "^6.0.0"
 			}
 		},
 		"node_modules/@types/jasmine": {
@@ -33,22 +33,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"node_modules/europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/neocotic"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/neocotic"
-				}
-			],
-			"peer": true
 		}
 	},
 	"dependencies": {
@@ -57,12 +41,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-plugin-quote/package.json
+++ b/packages/europa-plugin-quote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-plugin-quote",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Europa plugin to convert HTML tags to Markdown quotes",
   "keywords": [
     "block",
@@ -35,14 +35,14 @@
     "directory": "packages/europa-plugin-quote"
   },
   "peerDependencies": {
-    "europa-core": "^5.0.1"
+    "europa-core": "^6.0.0"
   },
   "devDependencies": {
     "@types/jasmine": "^4.0.3",
-    "europa-build": "^5.0.1",
-    "europa-core": "^5.0.1",
-    "europa-environment-node": "^5.0.1",
-    "europa-test-jasmine-reporter": "^5.0.1"
+    "europa-build": "^6.0.0",
+    "europa-core": "^6.0.0",
+    "europa-environment-node": "^6.0.0",
+    "europa-test-jasmine-reporter": "^6.0.0"
   },
   "scripts": {
     "build": "europa-build run-script build",

--- a/packages/europa-preset-default/package-lock.json
+++ b/packages/europa-preset-default/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-preset-default",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-preset-default",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -25,7 +25,7 @@
 				"node": "^12.20.0 || >=14"
 			},
 			"peerDependencies": {
-				"europa-core": "^5.0.1"
+				"europa-core": "^6.0.0"
 			}
 		},
 		"node_modules/@types/jasmine": {
@@ -33,22 +33,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"node_modules/europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/neocotic"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/neocotic"
-				}
-			],
-			"peer": true
 		}
 	},
 	"dependencies": {
@@ -57,12 +41,6 @@
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
 			"integrity": "sha512-Opp1LvvEuZdk8fSSvchK2mZwhVrsNT0JgJE9Di6MjnaIpmEXM8TLCPPrVtNTYh8+5MPdY8j9bAHMu2SSfwpZJg==",
 			"dev": true
-		},
-		"europa-core": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/europa-core/-/europa-core-5.0.1.tgz",
-			"integrity": "sha512-OD4mxmXmszyLOb3vmKxTlddFfspEltmGTdszuQG8mzJJTjqEP2+hiJ7/tQnsj57To6DZNuu6r/Kdq5RDZxvrUw==",
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-preset-default/package.json
+++ b/packages/europa-preset-default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-preset-default",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Default Europa preset",
   "keywords": [
     "default",
@@ -33,30 +33,30 @@
     "directory": "packages/europa-preset-default"
   },
   "dependencies": {
-    "europa-plugin-bold": "^5.0.1",
-    "europa-plugin-code": "^5.0.1",
-    "europa-plugin-description": "^5.0.1",
-    "europa-plugin-details": "^5.0.1",
-    "europa-plugin-header": "^5.0.1",
-    "europa-plugin-horizontal-rule": "^5.0.1",
-    "europa-plugin-image": "^5.0.1",
-    "europa-plugin-italic": "^5.0.1",
-    "europa-plugin-line-break": "^5.0.1",
-    "europa-plugin-link": "^5.0.1",
-    "europa-plugin-list": "^5.0.1",
-    "europa-plugin-paragraph": "^5.0.1",
-    "europa-plugin-preformatted": "^5.0.1",
-    "europa-plugin-quote": "^5.0.1"
+    "europa-plugin-bold": "^6.0.0",
+    "europa-plugin-code": "^6.0.0",
+    "europa-plugin-description": "^6.0.0",
+    "europa-plugin-details": "^6.0.0",
+    "europa-plugin-header": "^6.0.0",
+    "europa-plugin-horizontal-rule": "^6.0.0",
+    "europa-plugin-image": "^6.0.0",
+    "europa-plugin-italic": "^6.0.0",
+    "europa-plugin-line-break": "^6.0.0",
+    "europa-plugin-link": "^6.0.0",
+    "europa-plugin-list": "^6.0.0",
+    "europa-plugin-paragraph": "^6.0.0",
+    "europa-plugin-preformatted": "^6.0.0",
+    "europa-plugin-quote": "^6.0.0"
   },
   "peerDependencies": {
-    "europa-core": "^5.0.1"
+    "europa-core": "^6.0.0"
   },
   "devDependencies": {
     "@types/jasmine": "^4.0.3",
-    "europa-build": "^5.0.1",
-    "europa-core": "^5.0.1",
-    "europa-environment-node": "^5.0.1",
-    "europa-test-jasmine-reporter": "^5.0.1"
+    "europa-build": "^6.0.0",
+    "europa-core": "^6.0.0",
+    "europa-environment-node": "^6.0.0",
+    "europa-test-jasmine-reporter": "^6.0.0"
   },
   "scripts": {
     "build": "europa-build run-script build",

--- a/packages/europa-test-jasmine-reporter/package-lock.json
+++ b/packages/europa-test-jasmine-reporter/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-test-jasmine-reporter",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-test-jasmine-reporter",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -43,19 +43,6 @@
 			},
 			"peerDependencies": {
 				"jasmine": "^4.1.0"
-			}
-		},
-		"node_modules/@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -98,34 +85,6 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -161,34 +120,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/@tsconfig/node10": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node12": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node14": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node16": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/@types/jasmine": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
@@ -206,13 +137,6 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
-		},
-		"node_modules/@types/node": {
-			"version": "17.0.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-			"integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "5.26.0",
@@ -419,16 +343,6 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
-		"node_modules/acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -468,13 +382,6 @@
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
-		},
-		"node_modules/arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
@@ -626,13 +533,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"node_modules/create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -684,16 +584,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/dir-glob": {
@@ -1886,13 +1776,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2453,50 +2336,6 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/ts-node": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
-			"integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			},
-			"bin": {
-				"ts-node": "dist/bin.js",
-				"ts-node-cwd": "dist/bin-cwd.js",
-				"ts-node-esm": "dist/bin-esm.js",
-				"ts-node-script": "dist/bin-script.js",
-				"ts-node-transpile-only": "dist/bin-transpile.js",
-				"ts-script": "dist/bin-script-deprecated.js"
-			},
-			"peerDependencies": {
-				"@swc/core": ">=1.2.50",
-				"@swc/wasm": ">=1.2.50",
-				"@types/node": "*",
-				"typescript": ">=2.7"
-			},
-			"peerDependenciesMeta": {
-				"@swc/core": {
-					"optional": true
-				},
-				"@swc/wasm": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/tsconfig-paths": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz",
@@ -2625,13 +2464,6 @@
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
-		"node_modules/v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2683,29 +2515,9 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"node_modules/yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6"
-			}
 		}
 	},
 	"dependencies": {
-		"@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			}
-		},
 		"@eslint/eslintrc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -2740,31 +2552,6 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"@jridgewell/resolve-uri": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
-			"dev": true,
-			"peer": true
-		},
-		"@jridgewell/sourcemap-codec": {
-			"version": "1.4.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
-			"dev": true,
-			"peer": true
-		},
-		"@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2791,34 +2578,6 @@
 				"fastq": "^1.6.0"
 			}
 		},
-		"@tsconfig/node10": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node12": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node14": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node16": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-			"dev": true,
-			"peer": true
-		},
 		"@types/jasmine": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
@@ -2836,13 +2595,6 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
-		},
-		"@types/node": {
-			"version": "17.0.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-			"integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
-			"dev": true,
-			"peer": true
 		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "5.26.0",
@@ -2949,15 +2701,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
-			"requires": {}
-		},
-		"acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"ajv": {
 			"version": "6.12.6",
@@ -2985,13 +2729,6 @@
 			"requires": {
 				"color-convert": "^2.0.1"
 			}
-		},
-		"arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"peer": true
 		},
 		"argparse": {
 			"version": "2.0.1",
@@ -3107,13 +2844,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"peer": true
-		},
 		"cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3149,13 +2879,6 @@
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
 			}
-		},
-		"diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"peer": true
 		},
 		"dir-glob": {
 			"version": "3.0.1",
@@ -3297,8 +3020,7 @@
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
 			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",
@@ -4059,13 +3781,6 @@
 				"yallist": "^4.0.0"
 			}
 		},
-		"make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"peer": true
-		},
 		"merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4441,28 +4156,6 @@
 				"is-number": "^7.0.0"
 			}
 		},
-		"ts-node": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
-			"integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			}
-		},
 		"tsconfig-paths": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz",
@@ -4555,13 +4248,6 @@
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
-		"v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"peer": true
-		},
 		"which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4601,13 +4287,6 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-test-jasmine-reporter/package.json
+++ b/packages/europa-test-jasmine-reporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-test-jasmine-reporter",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Jasmine reporter for testing Europa packages",
   "keywords": [
     "europa",

--- a/packages/europa-test/package-lock.json
+++ b/packages/europa-test/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-test",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-test",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -40,19 +40,6 @@
 			},
 			"peerDependencies": {
 				"jasmine": "^4.1.0"
-			}
-		},
-		"node_modules/@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -95,34 +82,6 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -158,34 +117,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/@tsconfig/node10": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node12": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node14": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/@tsconfig/node16": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/@types/jasmine": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
@@ -203,13 +134,6 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
-		},
-		"node_modules/@types/node": {
-			"version": "17.0.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-			"integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "5.26.0",
@@ -416,16 +340,6 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
-		"node_modules/acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -465,13 +379,6 @@
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
-		},
-		"node_modules/arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
@@ -615,13 +522,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"node_modules/create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -673,16 +573,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/dir-glob": {
@@ -1867,13 +1757,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2434,50 +2317,6 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/ts-node": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
-			"integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			},
-			"bin": {
-				"ts-node": "dist/bin.js",
-				"ts-node-cwd": "dist/bin-cwd.js",
-				"ts-node-esm": "dist/bin-esm.js",
-				"ts-node-script": "dist/bin-script.js",
-				"ts-node-transpile-only": "dist/bin-transpile.js",
-				"ts-script": "dist/bin-script-deprecated.js"
-			},
-			"peerDependencies": {
-				"@swc/core": ">=1.2.50",
-				"@swc/wasm": ">=1.2.50",
-				"@types/node": "*",
-				"typescript": ">=2.7"
-			},
-			"peerDependenciesMeta": {
-				"@swc/core": {
-					"optional": true
-				},
-				"@swc/wasm": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/tsconfig-paths": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz",
@@ -2606,13 +2445,6 @@
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
-		"node_modules/v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2664,29 +2496,9 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"node_modules/yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6"
-			}
 		}
 	},
 	"dependencies": {
-		"@cspotcode/source-map-support": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/trace-mapping": "0.3.9"
-			}
-		},
 		"@eslint/eslintrc": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -2721,31 +2533,6 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"@jridgewell/resolve-uri": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-			"integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
-			"dev": true,
-			"peer": true
-		},
-		"@jridgewell/sourcemap-codec": {
-			"version": "1.4.13",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-			"integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
-			"dev": true,
-			"peer": true
-		},
-		"@jridgewell/trace-mapping": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/resolve-uri": "^3.0.3",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			}
-		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2772,34 +2559,6 @@
 				"fastq": "^1.6.0"
 			}
 		},
-		"@tsconfig/node10": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-			"integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node12": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-			"integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node14": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-			"integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-			"dev": true,
-			"peer": true
-		},
-		"@tsconfig/node16": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-			"dev": true,
-			"peer": true
-		},
 		"@types/jasmine": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-4.0.3.tgz",
@@ -2817,13 +2576,6 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
-		},
-		"@types/node": {
-			"version": "17.0.35",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
-			"integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
-			"dev": true,
-			"peer": true
 		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "5.26.0",
@@ -2930,15 +2682,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
-			"requires": {}
-		},
-		"acorn-walk": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"ajv": {
 			"version": "6.12.6",
@@ -2966,13 +2710,6 @@
 			"requires": {
 				"color-convert": "^2.0.1"
 			}
-		},
-		"arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"peer": true
 		},
 		"argparse": {
 			"version": "2.0.1",
@@ -3083,13 +2820,6 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
-		"create-require": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"peer": true
-		},
 		"cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3125,13 +2855,6 @@
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
 			}
-		},
-		"diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"peer": true
 		},
 		"dir-glob": {
 			"version": "3.0.1",
@@ -3273,8 +2996,7 @@
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
 			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",
@@ -4027,13 +3749,6 @@
 				"yallist": "^4.0.0"
 			}
 		},
-		"make-error": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"peer": true
-		},
 		"merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4409,28 +4124,6 @@
 				"is-number": "^7.0.0"
 			}
 		},
-		"ts-node": {
-			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
-			"integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@cspotcode/source-map-support": "^0.8.0",
-				"@tsconfig/node10": "^1.0.7",
-				"@tsconfig/node12": "^1.0.7",
-				"@tsconfig/node14": "^1.0.0",
-				"@tsconfig/node16": "^1.0.2",
-				"acorn": "^8.4.1",
-				"acorn-walk": "^8.1.1",
-				"arg": "^4.1.0",
-				"create-require": "^1.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"v8-compile-cache-lib": "^3.0.1",
-				"yn": "3.1.1"
-			}
-		},
 		"tsconfig-paths": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz",
@@ -4523,13 +4216,6 @@
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
-		"v8-compile-cache-lib": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"peer": true
-		},
 		"which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4569,13 +4255,6 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"peer": true
 		}
 	}
 }

--- a/packages/europa-test/package.json
+++ b/packages/europa-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-test",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Test framework for Europa Core implementations",
   "keywords": [
     "europa",
@@ -33,7 +33,7 @@
     "directory": "packages/europa-test"
   },
   "dependencies": {
-    "europa-core": "^5.0.1"
+    "europa-core": "^6.0.0"
   },
   "peerDependencies": {
     "jasmine": "^4.1.0"

--- a/packages/europa-worker/package-lock.json
+++ b/packages/europa-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa-worker",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa-worker",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -5741,8 +5741,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
 			"integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@webpack-cli/info": {
 			"version": "1.4.1",
@@ -5757,8 +5756,7 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
 			"integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@xtuc/ieee754": {
 			"version": "1.2.0",
@@ -5792,15 +5790,13 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
 			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"acorn-walk": {
 			"version": "8.2.0",
@@ -5833,8 +5829,7 @@
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"ansi-regex": {
 			"version": "5.0.1",
@@ -6391,8 +6386,7 @@
 					"version": "8.2.3",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
 					"integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-					"dev": true,
-					"requires": {}
+					"dev": true
 				}
 			}
 		},
@@ -6564,8 +6558,7 @@
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
 			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",
@@ -9066,8 +9059,7 @@
 					"version": "7.5.7",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
 					"integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-					"dev": true,
-					"requires": {}
+					"dev": true
 				}
 			}
 		},
@@ -9189,8 +9181,7 @@
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
 			"integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"y18n": {
 			"version": "5.0.8",

--- a/packages/europa-worker/package.json
+++ b/packages/europa-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa-worker",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Library for converting HTML into valid Markdown within a worker",
   "keywords": [
     "europa",
@@ -34,7 +34,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/neocotic/europa.git",
-    "directory":  "packages/europa-worker"
+    "directory": "packages/europa-worker"
   },
   "devDependencies": {
     "@types/jasmine": "^4.0.3",
@@ -45,14 +45,14 @@
     "eslint-import-resolver-typescript": "^2.7.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "europa-core": "^5.0.1",
-    "europa-environment-worker": "^5.0.1",
-    "europa-preset-default": "^5.0.1",
-    "europa-test": "^5.0.1",
+    "europa-core": "^6.0.0",
+    "europa-environment-worker": "^6.0.0",
+    "europa-preset-default": "^6.0.0",
+    "europa-test": "^6.0.0",
     "jasmine": "^4.1.0",
     "karma": "^6.3.19",
-    "karma-cli": "^2.0.0",
     "karma-chrome-launcher": "^3.1.1",
+    "karma-cli": "^2.0.0",
     "karma-jasmine": "^5.0.0",
     "karma-spec-reporter": "^0.0.34",
     "karma-webpack": "^5.0.0",
@@ -67,8 +67,8 @@
     "typescript-declaration-webpack-plugin": "^0.2.2",
     "typescript-transform-paths": "^3.3.1",
     "webpack": "^5.72.0",
-    "webpack-cli": "^4.9.2",
-    "webpack-bundle-analyzer": "^4.5.0"
+    "webpack-bundle-analyzer": "^4.5.0",
+    "webpack-cli": "^4.9.2"
   },
   "scripts": {
     "analyze:esm": "webpack --config webpack.esm.config.js --analyze",

--- a/packages/europa/package-lock.json
+++ b/packages/europa/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "europa",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "europa",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -5741,8 +5741,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
 			"integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@webpack-cli/info": {
 			"version": "1.4.1",
@@ -5757,8 +5756,7 @@
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
 			"integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@xtuc/ieee754": {
 			"version": "1.2.0",
@@ -5792,15 +5790,13 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
 			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"acorn-walk": {
 			"version": "8.2.0",
@@ -5833,8 +5829,7 @@
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"ansi-regex": {
 			"version": "5.0.1",
@@ -6391,8 +6386,7 @@
 					"version": "8.2.3",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
 					"integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-					"dev": true,
-					"requires": {}
+					"dev": true
 				}
 			}
 		},
@@ -6564,8 +6558,7 @@
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
 			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",
@@ -9066,8 +9059,7 @@
 					"version": "7.5.7",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
 					"integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-					"dev": true,
-					"requires": {}
+					"dev": true
 				}
 			}
 		},
@@ -9189,8 +9181,7 @@
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
 			"integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"y18n": {
 			"version": "5.0.8",

--- a/packages/europa/package.json
+++ b/packages/europa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "europa",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Library for converting HTML into valid Markdown within a web browser",
   "keywords": [
     "europa",
@@ -34,7 +34,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/neocotic/europa.git",
-    "directory":  "packages/europa"
+    "directory": "packages/europa"
   },
   "devDependencies": {
     "@types/jasmine": "^4.0.3",
@@ -45,14 +45,14 @@
     "eslint-import-resolver-typescript": "^2.7.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "europa-core": "^5.0.1",
-    "europa-environment-web": "^5.0.1",
-    "europa-preset-default": "^5.0.1",
-    "europa-test": "^5.0.1",
+    "europa-core": "^6.0.0",
+    "europa-environment-web": "^6.0.0",
+    "europa-preset-default": "^6.0.0",
+    "europa-test": "^6.0.0",
     "jasmine": "^4.1.0",
     "karma": "^6.3.19",
-    "karma-cli": "^2.0.0",
     "karma-chrome-launcher": "^3.1.1",
+    "karma-cli": "^2.0.0",
     "karma-jasmine": "^5.0.0",
     "karma-spec-reporter": "^0.0.34",
     "karma-webpack": "^5.0.0",
@@ -67,8 +67,8 @@
     "typescript-declaration-webpack-plugin": "^0.2.2",
     "typescript-transform-paths": "^3.3.1",
     "webpack": "^5.72.0",
-    "webpack-cli": "^4.9.2",
-    "webpack-bundle-analyzer": "^4.5.0"
+    "webpack-bundle-analyzer": "^4.5.0",
+    "webpack-cli": "^4.9.2"
   },
   "scripts": {
     "analyze:esm": "webpack --config webpack.esm.config.js --analyze",

--- a/packages/node-europa/package-lock.json
+++ b/packages/node-europa/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "node-europa",
-	"version": "5.0.1",
+	"version": "6.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "node-europa",
-			"version": "5.0.1",
+			"version": "6.0.0",
 			"funding": [
 				{
 					"type": "individual",
@@ -2903,8 +2903,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"acorn-walk": {
 			"version": "8.2.0",
@@ -3242,8 +3241,7 @@
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
 			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",

--- a/packages/node-europa/package.json
+++ b/packages/node-europa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-europa",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Library for converting HTML into valid Markdown within Node.js",
   "keywords": [
     "europa",
@@ -36,9 +36,9 @@
     "directory": "packages/node-europa"
   },
   "dependencies": {
-    "europa-core": "^5.0.1",
-    "europa-environment-node": "^5.0.1",
-    "europa-preset-default": "^5.0.1"
+    "europa-core": "^6.0.0",
+    "europa-environment-node": "^6.0.0",
+    "europa-preset-default": "^6.0.0"
   },
   "devDependencies": {
     "@types/jasmine": "^4.0.3",
@@ -50,8 +50,8 @@
     "eslint-import-resolver-typescript": "^2.7.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "europa-test": "^5.0.1",
-    "europa-test-jasmine-reporter": "^5.0.1",
+    "europa-test": "^6.0.0",
+    "europa-test-jasmine-reporter": "^6.0.0",
     "jasmine": "^4.1.0",
     "prettier": "^2.6.2",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
* Improve compatibility with Markdown standards
* Completely refactor plugin and preset API
* Move built-in plugins and default preset into separate packages
* Add tests for all official plugins and presets
* Change reference numbering for anchor and image tags to a one-based index
* Rename anchor tag referencing from `anchorN` to `linkN`
* Simplify reference management for plugins
* Refactor options API to ensure immutability
* Move plugin-specific text conversion and escape logic to plugins
* Refactor internal environment management for Europa Core implementations and introduce DOM wrappers
* Create **europa-worker** package to allow usage of Europa within a service/web worker
* Add `eol` option to override the environment-specific end of line character
* Create **europa-build** package to simplify generation and maintenance of plugin/preset packages
* Include comments in generated TypeScript declaration files
* Fix build status shields
* **node-europa**: Replace `jsdom` with `cheerio`
* **node-europa**: Move CLI into a new **europa-cli** package